### PR TITLE
Improved OS version metadata in CUDADriver.munki

### DIFF
--- a/NVIDIA/CUDADriver.munki.recipe
+++ b/NVIDIA/CUDADriver.munki.recipe
@@ -3,11 +3,20 @@
 <plist version="1.0">
 <dict>
 	<key>description</key>
-	<string>Downloads latest NVIDIA CUDA Driver and imports into Munki.</string>
+	<string>Downloads latest NVIDIA CUDA Driver and imports into Munki.
+
+Set MAJOR_OS_VERSION to the version of OS X that will be evaluated against
+NVIDIA's feed of available driver downloads for various OS versions.
+
+The resultant pkginfo will automatically have its 'minimum_os_version'
+pkginfo set according to the lowest OS version supported by the
+found driver download.</string>
 	<key>Input</key>
 	<dict>
 		<key>IDENTIFIER</key>
 		<string>com.github.jessepeterson.munki.CUDADriver</string>
+		<key>MAJOR_OS_VERSION</key>
+		<string>10.10</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>drivers</string>
 		<key>MUNKI_CATEGORY</key>
@@ -33,6 +42,11 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>cuda_os_ver</key>
+				<string>%MAJOR_OS_VERSION%</string>
+			</dict>
 			<key>Processor</key>
 			<string>CUDADriverURLProvider</string>
 		</dict>
@@ -120,6 +134,8 @@
 			<dict>
 				<key>additional_pkginfo</key>
 				<dict>
+					<key>minimum_os_version</key>
+					<string>%minimum_os_version%</string>
 					<key>version</key>
 					<string>%version%</string>
 				</dict>

--- a/NVIDIA/CUDADriverURLProvider.py
+++ b/NVIDIA/CUDADriverURLProvider.py
@@ -23,12 +23,23 @@ class CUDADriverURLProvider(Processor):
 			},
 	}
 	output_variables = {
+		'minimum_os_version': {
+			'description': 'Minimum OS version requirement of the Driver DMG download.'
+		},
 		'url': {
-			'description': 'URL to the latest CUDA Driver DMG download'
-		}
+			'description': 'URL to the latest CUDA Driver DMG download.'
+		},
 	}
 
 	description = __doc__
+
+	def evaluate_predicate(self, eval_obj, predicate_str):
+		try:
+			predicate = NSPredicate.predicateWithFormat_(predicate_str)
+		except:
+			raise ProcessorError('Problem with NSPredicate: %s' % rule['Predicate'])
+		return predicate.evaluateWithObject_(eval_obj)
+
 
 	def get_url(self, os_ver):
 		try:
@@ -56,24 +67,39 @@ class CUDADriverURLProvider(Processor):
 		# testing it to not be the current version.
 		pred_obj = {'Ticket': {'Version': ''}, 'SystemVersion': {'ProductVersion': os_ver}}
 
+		url = None
 		for rule in plist['Rules']:
-			try:
-				predicate = NSPredicate.predicateWithFormat_(rule['Predicate'])
-			except:
-				raise ProcessorError('Problem with NSPredicate: %s' % rule['Predicate'])
-	
-			if predicate.evaluateWithObject_(pred_obj):
-				return rule['Codebase']
-			
-		raise ProcessorError('No valid Predicate rules found!')
+			if self.evaluate_predicate(pred_obj, rule['Predicate']):
+				self.output('Satisfied predicate for OS version %s' % os_ver)
+				url = rule['Codebase']
+
+				# with a satisfied predicate, evaluate lower OS versions
+				# so as to determine a minimum OS constraint, decrementing
+				# one 10.x version at a time
+				while self.evaluate_predicate(pred_obj, rule['Predicate']):
+					# record the currently-evaluated OS version as the minimum required
+					minimum_os_ver = os_ver
+					osx, major = os_ver.split('.')
+					os_ver = osx + '.' + str(int(major) - 1)
+					pred_obj['SystemVersion']['ProductVersion'] = os_ver
+					self.output('Evaluating predicate for lower OS version %s' % os_ver)
+				self.output('OS version %s too low!' % os_ver)
+				# highest required versions seem to be always first, so we break
+				# after we've satisfied one Predicate
+				break
+
+
+		if not url:
+			raise ProcessorError('No valid Predicate rules found!')
+		return (url, minimum_os_ver)
 
 	def main(self):
 		if 'cuda_os_ver' in self.env:
 			cuda_os_ver = self.env['cuda_os_ver']
 		else:
-			cuda_os_ver = '10.8'
+			cuda_os_ver = '10.10'
 
-		self.env['url'] = self.get_url(cuda_os_ver)
+		self.env['url'], self.env['minimum_os_version'] = self.get_url(cuda_os_ver)
 		self.output('File URL %s' % self.env['url'])
 
 if __name__ == '__main__':


### PR DESCRIPTION
A few handy improvements to the CUDA recipe. I started just with the intention of adding the input variable but then decided it's useful to have the recipe automatically handle the version constraints, so now it keeps attempting a lower version in the predicate object until it returns False.

Not sure whether it would be also handy to set a `maximum_os_version` as some protective measure - but I think in most cases admins when keeping this recipe in rotation will end up having the newer drivers available anyway. Also, I don't think one can assume that a driver for 10.10 _won't_ work on 10.11 in all cases, for example.

Not attached to the name `MAJOR_OS_VERSION` for the Input variable, if you have any ideas. 