### PR TITLE
Updated LoginScriptPlugin munki recipe

### DIFF
--- a/LoginScriptPlugin/LoginScriptPlugin.munki.recipe
+++ b/LoginScriptPlugin/LoginScriptPlugin.munki.recipe
@@ -73,7 +73,7 @@
 				<key>source_flatpkg_dir</key>
 				<string>%RECIPE_CACHE_DIR%/unpack</string>
 				<key>destination_pkg</key>
-				<string>%RECIPE_CACHE_DIR%/repack</string>
+				<string>%RECIPE_CACHE_DIR%/LoginScriptPlugin.pkg</string>
 			</dict>
 		</dict>
 		<dict>
@@ -82,7 +82,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/repack</string>
+				<string>%RECIPE_CACHE_DIR%/LoginScriptPlugin.pkg</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 				<key>additional_makepkginfo_options</key>

--- a/LoginScriptPlugin/LoginScriptPlugin.munki.recipe
+++ b/LoginScriptPlugin/LoginScriptPlugin.munki.recipe
@@ -58,6 +58,24 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
+			<string>FileCreator</string>
+			<key>Arguments</key>
+			<dict>
+				<key>file_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/LoginScriptPlugin.pkg/Scripts/postinstall</string>
+				<key>file_mode</key>
+				<string>0755</string>
+				<key>file_content</key>
+				<string>#!/bin/bash
+
+# Configure the authorization db to enable the plugin.
+./configureplugin.sh enable
+
+exit 0</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>LoginScriptPluginUninstallCreator</string>
 			<key>Arguments</key>
 			<dict>

--- a/LoginScriptPlugin/LoginScriptPlugin.munki.recipe
+++ b/LoginScriptPlugin/LoginScriptPlugin.munki.recipe
@@ -82,7 +82,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%pathname%</string>
+				<string>%RECIPE_CACHE_DIR%/repack</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 				<key>additional_makepkginfo_options</key>

--- a/LoginScriptPlugin/LoginScriptPlugin.munki.recipe
+++ b/LoginScriptPlugin/LoginScriptPlugin.munki.recipe
@@ -73,7 +73,7 @@
 				<key>source_flatpkg_dir</key>
 				<string>%RECIPE_CACHE_DIR%/unpack</string>
 				<key>destination_pkg</key>
-				<string>%pathname%</string>
+				<string>%RECIPE_CACHE_DIR%/repack</string>
 			</dict>
 		</dict>
 		<dict>

--- a/LoginScriptPlugin/LoginScriptPlugin.munki.recipe
+++ b/LoginScriptPlugin/LoginScriptPlugin.munki.recipe
@@ -47,11 +47,33 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
+			<string>PathDeleter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/unpack/LoginScriptPlugin.pkg/Scripts/postinstall</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>LoginScriptPluginUninstallCreator</string>
 			<key>Arguments</key>
 			<dict>
 				<key>script_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/LoginScriptPlugin.pkg/Scripts/configureplugin.sh</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>FlatPkgPacker</string>
+			<key>Arguments</key>
+			<dict>
+				<key>source_flatpkg_dir</key>
+				<string>%RECIPE_CACHE_DIR%/unpack</string>
+				<key>destination_pkg</key>
+				<string>%pathname%</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Updated LoginScriptPlugin munki recipe to remove postinstall script that killed loginwindow.app as it caused issues when installed in logged out state via Munki