### PR TITLE
Update ImageConverter.py

### DIFF
--- a/VMware/ImageConverter.py
+++ b/VMware/ImageConverter.py
@@ -7,51 +7,57 @@ from autopkglib import Processor, ProcessorError
 __all__ = ["ImageConverter"]
 
 class ImageConverter(Processor):
-	'''Provides URL to the latest Darwin ISO of the VMware Fusion tools.'''
+    '''Provides URL to the latest Darwin ISO of the VMware Fusion tools.'''
 
-	input_variables = {
-		'image_source': {
-			'required': True,
-			'description': 'Source image file',
-			},
-		'image_destination': {
-			'required': True,
-			'description': 'Output image file',
-			},
-		'image_format': {
-			'required': True,
-			'description': 'See hdiutil(1) manual for various image formats. E.g. UDTO',
-			},
-		'remove_destination': {
-			'required': False,
-			'description': 'Remove destination image file if it exists',
-			},
-	}
-	output_variables = {
-	}
+    input_variables = {
+        'image_source': {
+            'required': True,
+            'description': 'Source image file',
+            },
+        'image_destination': {
+            'required': True,
+            'description': 'Output image file',
+            },
+        'image_format': {
+            'required': True,
+            'description': 'See hdiutil(1) manual for various image formats. E.g. UDTO',
+            },
+        'remove_destination': {
+            'required': False,
+            'description': 'Remove destination image file if it exists',
+            },
+    }
+    output_variables = {
+    }
 
-	def main(self):
-		if os.path.exists(self.env.get("image_destination")):
-			if self.env.get("remove_destination", True):
-				os.unlink(self.env.get("image_destination"))
-			else:
-				raise ProcessorError('image_destination exists')
+    def main(self):
+        if os.path.exists(self.env.get("image_destination")):
+            if self.env.get("remove_destination", True):
+                os.unlink(self.env.get("image_destination"))
+            else:
+                raise ProcessorError('image_destination exists')
 
-		cmd = ['/usr/bin/hdiutil',
-		       'convert',
-		       self.env.get("image_source"),
-		       '-format',
-		       self.env.get("image_format"),
-		       '-o',
-		       self.env.get("image_destination"),
-		       ]
+        cmd = ['/usr/bin/hdiutil',
+               'convert',
+               self.env.get("image_source"),
+               '-format',
+               self.env.get("image_format"),
+               '-o',
+               self.env.get("image_destination"),
+               ]
 
-		proc = subprocess.Popen(cmd)
-		proc.communicate()
-		if proc.returncode != 0:
-			raise ProcessorError('hdiutil convert exited abnormally')
+        proc = subprocess.Popen(cmd,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+        proc.communicate()
+        if proc.returncode != 0:
+            raise ProcessorError('hdiutil convert exited abnormally')
+
+        self.output("Converted %s to %s"
+                     % (self.env["image_source"],
+                        self.env["image_destination"]))
+
 
 if __name__ == '__main__':
-	processor = ImageConverter()
-	processor.execute_shell()
-
+    processor = ImageConverter()
+    processor.execute_shell()


### PR DESCRIPTION
Convert tabs to spaces. Add stdout and stderr options to subprocess.Popen call so that hdiutil output does not get barfed to STDOUT. Changes this:

```
# autopkg run VMwareTools.munki.recipe
Processing VMwareTools.munki...
Preparing imaging engine…
Reading Driver Descriptor Map (DDM : 0)…
   (CRC32 $0651E048: Driver Descriptor Map (DDM : 0))
Reading Apple (Apple_partition_map : 1)…
..
   (CRC32 $80E108CC: Apple (Apple_partition_map : 1))
Reading DiscRecording 8.0d6 (Apple_HFS : 2)…
.....................................................................................................................................................................................................
   (CRC32 $F0B6EFCE: DiscRecording 8.0d6 (Apple_HFS : 2))
Adding resources…
.....................................................................................................................................................................................................
Elapsed Time: 870.048ms
File size: 2577554 bytes, Checksum: CRC32 $ABA5F65A
Sectors processed: 6048, 6045 compressed
Speed: 3.4Mbytes/sec
Savings: 16.8%
created: /Users/gneagle/Library/AutoPkg/Cache/local.munki.VMwareTools/VMwareTools.dmg
```

to this:

```
# autopkg run VMwareTools.munki.recipe
Processing VMwareTools.munki.recipe...

```

Verbose output for the ImageConverter step looks like:

```
ImageConverter
ImageConverter: Converted /Users/gneagle/Library/AutoPkg/Cache/local.munki.VMwareTools/VMwareTools/payload/darwin.iso to /Users/gneagle/Library/AutoPkg/Cache/local.munki.VMwareTools/VMwareTools.dmg
```