### PR TITLE
add codesigverif to iBarcoder

### DIFF
--- a/Cristallight/iBarcoder.download.recipe
+++ b/Cristallight/iBarcoder.download.recipe
@@ -13,6 +13,8 @@
 		<key>url</key>
 		<string>http://www.cristallight.com/Downloads/mac/ibarcoder.dmg</string>
 	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
@@ -22,6 +24,21 @@
 			<dict>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
+			</dict>
+		</dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/%NAME%.app</string>
+				<key>requirement</key>
+				<string>anchor apple generic and identifier "com.cristallight.ibar" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = JAXVB9AH9M)</string>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
and end of check phase. Hope it's OK I bumped the version requirement
to most recent autopkg, since only higher than .3.1 had codesigverif in
core.