### PR TITLE
Update MAJOR_OS_VERSION in CUDADriver.munki to 10.12

### DIFF
--- a/NVIDIA/CUDADriver.download.recipe
+++ b/NVIDIA/CUDADriver.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>MAJOR_OS_VERSION</key>
-		<string>10.10</string>
+		<string>10.12</string>
 		<key>NAME</key>
 		<string>CUDADriver</string>
 	</dict>


### PR DESCRIPTION
Just noticed CUDA 8 had been out for a while but this recipe was still retrieving a 7.x version. Bumping `MAJOR_OS_VERSION` to either 10.11 or 10.12 will retrieve the latest version - figured I would put it to the latest since currently that doesn't "skip" any supported versions.