### PR TITLE
Require 10.11 for VMwareTools.munki

### DIFF
--- a/VMware/VMwareTools.munki.recipe
+++ b/VMware/VMwareTools.munki.recipe
@@ -34,6 +34,8 @@ Other tools in the package support synchronization of time in the guest operatin
 			<array>
 				<string>testing</string>
 			</array>
+			<key>minimum_os_version</key>
+			<string>10.11</string>
 		</dict>
 	</dict>
 	<key>Process</key>


### PR DESCRIPTION
As of 8.5.4, Fusion now ships two different darwin tools ISOs: `darwin.iso` and `darwinPre15.iso`. `darwin.iso` now has a minimum OS of 10.11 set in its pkg distribution file. So this just sets the `minimum_os_version` to match.

Not sure how much of a demand there is to keep older VMs up to date, but perhaps that would call for a duplicate recipe like `VMwareToolsYosemite.munki` (or something) which has a `maximum_os_version` of `10.10.5`. Figured the first part is the lower-hanging fruit and would affect the most users.