### PR TITLE
Add pkg signature validation to CUDADriver.download

### DIFF
--- a/NVIDIA/CUDADriver.download.recipe
+++ b/NVIDIA/CUDADriver.download.recipe
@@ -37,6 +37,21 @@
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/CUDADriver.pkg</string>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: NVIDIA Corporation</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This one just adds pkg signature validation to the installer package for the CUDA driver.