### PR TITLE
Update UTC6 url

### DIFF
--- a/Extensis/UniversalTypeClient6.download.recipe
+++ b/Extensis/UniversalTypeClient6.download.recipe
@@ -21,7 +21,7 @@
 				<key>re_pattern</key>
 				<string>(?P&lt;url&gt;http://bin.extensis.com/UTC-6-[0-9\-]*-M\.zip)</string>
 				<key>url</key>
-				<string>http://www.extensis.com/support/product-support/universal-type-server-6/</string>
+				<string>https://www.extensis.com/support/universal-type-server-6-support/</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>


### PR DESCRIPTION
Extensis redid their website and that changed patching. This corrects the URL. Zip file naming regex still works.