### PR TITLE
Update VMwareToolsURLProvider.py

### DIFF
--- a/VMware/VMwareToolsURLProvider.py
+++ b/VMware/VMwareToolsURLProvider.py
@@ -10,7 +10,7 @@ __all__ = ["VMwareToolsURLProvider"]
 
 FUSION_URL_BASE = 'https://softwareupdate.vmware.com/cds/vmw-desktop/'
 DARWIN_TOOLS_URL_APPEND = 'packages/com.vmware.fusion.tools.darwin.zip.tar'
-DEFAULT_VERSION_SERIES = '10.0.0'
+DEFAULT_VERSION_SERIES = '10.1.0'
 
 class VMwareToolsURLProvider(Processor):
 	'''Provides URL to the latest Darwin ISO of the VMware Fusion tools.'''


### PR DESCRIPTION
Update `DEFAULT_VERSION_SERIES` to `10.1.0`, in order to get the latest VMware Tools.