### PR TITLE
VMware Tools update

### DIFF
--- a/VMware/VMwareTools.munki.recipe
+++ b/VMware/VMwareTools.munki.recipe
@@ -103,7 +103,7 @@ Other tools in the package support synchronization of time in the guest operatin
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg/Install VMware Tools.app/Contents/Resources/VMware Tools.pkg</string>
 				<key>expected_authority_names</key>
 				<array>
-					<string>Developer ID Application: VMware, Inc. (EG7KH642X6)</string>
+					<string>Developer ID Installer: VMware, Inc. (EG7KH642X6)</string>
 					<string>Developer ID Certification Authority</string>
 					<string>Apple Root CA</string>
 				</array>

--- a/VMware/VMwareToolsURLProvider.py
+++ b/VMware/VMwareToolsURLProvider.py
@@ -10,7 +10,7 @@ __all__ = ["VMwareToolsURLProvider"]
 
 FUSION_URL_BASE = 'https://softwareupdate.vmware.com/cds/vmw-desktop/'
 DARWIN_TOOLS_URL_APPEND = 'packages/com.vmware.fusion.tools.darwin.zip.tar'
-DEFAULT_VERSION_SERIES = '10.1.0'
+DEFAULT_VERSION_SERIES = '11.0.0'
 
 class VMwareToolsURLProvider(Processor):
 	'''Provides URL to the latest Darwin ISO of the VMware Fusion tools.'''


### PR DESCRIPTION
Hey Jesse, I found these changes were necessary to support version 11 of the VMware Tools.