### PR TITLE
Set minimum OS version for dockutil to 10.9

### DIFF
--- a/dockutil/dockutil.munki.recipe
+++ b/dockutil/dockutil.munki.recipe
@@ -32,6 +32,8 @@
 			<string>command line tool for managing dock items</string>
 			<key>developer</key>
 			<string>%MUNKI_DEVELOPER%</string>
+			<key>minimum_os_version</key>
+			<string>10.9</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>


### PR DESCRIPTION
According to the read me: https://github.com/kcrawford/dockutil
> Compatible with Mac OS X 10.9.x thru 10.13 (use 1.x version for older OSes)