### PR TITLE
Basic python3 compatibility

### DIFF
--- a/Extensis/FindResource.py
+++ b/Extensis/FindResource.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 import os
 

--- a/Extensis/FindResource.py
+++ b/Extensis/FindResource.py
@@ -7,41 +7,41 @@ import os
 __all__ = ["FindResource"]
 
 class FindResource(Processor):
-	'''Finds a file resource in the current rescipe directory, or any parent recipe directories'''
+    '''Finds a file resource in the current rescipe directory, or any parent recipe directories'''
 
-	input_variables = {
-		'filename': {
-			'required': True,
-			'description': 'Name of filename resource',
-		},
-		'output_var_name': {
-			'required': False,
-			'description': 'Name of environment variable to output found file. Defaults to "found_resource"'
-		},
-	}
-	output_variables = {
-		'output_var_name': {
-			'description': 'Name of environment variable to output found file. Defaults to "found_resource"'
-		},
-	}
+    input_variables = {
+        'filename': {
+            'required': True,
+            'description': 'Name of filename resource',
+        },
+        'output_var_name': {
+            'required': False,
+            'description': 'Name of environment variable to output found file. Defaults to "found_resource"'
+        },
+    }
+    output_variables = {
+        'output_var_name': {
+            'description': 'Name of environment variable to output found file. Defaults to "found_resource"'
+        },
+    }
 
-	def main(self):
-		filename = self.env.get('filename', None)
+    def main(self):
+        filename = self.env.get('filename', None)
 
-		output_var = self.env.get('output_var_name', 'found_resource')
+        output_var = self.env.get('output_var_name', 'found_resource')
 
-		resource_file = os.path.join(self.env.get('RECIPE_DIR'), filename)
-		if os.path.exists(resource_file):
-			self.env[output_var] = resource_file
-			self.output('Found resource in current recipe dir: %s' % resource_file)
-			return
+        resource_file = os.path.join(self.env.get('RECIPE_DIR'), filename)
+        if os.path.exists(resource_file):
+            self.env[output_var] = resource_file
+            self.output('Found resource in current recipe dir: %s' % resource_file)
+            return
 
-		for parent_recipe in self.env.get('PARENT_RECIPES', []):
-			resource_file = os.path.join(os.path.dirname(parent_recipe), filename)
+        for parent_recipe in self.env.get('PARENT_RECIPES', []):
+            resource_file = os.path.join(os.path.dirname(parent_recipe), filename)
 
-			if os.path.exists(resource_file):
-				self.env[output_var] = resource_file
-				self.output('Found resource in parent recipe dir: %s' % resource_file)
-				return
+            if os.path.exists(resource_file):
+                self.env[output_var] = resource_file
+                self.output('Found resource in parent recipe dir: %s' % resource_file)
+                return
 
-		self.output('Could not find resource "%s" in recipe dir nor parent recipe dirs' % filename)
+        self.output('Could not find resource "%s" in recipe dir nor parent recipe dirs' % filename)

--- a/Extensis/FindResource.py
+++ b/Extensis/FindResource.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
+
 import os
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["FindResource"]
 

--- a/Extensis/ModeChanger.py
+++ b/Extensis/ModeChanger.py
@@ -8,27 +8,27 @@ import os
 __all__ = ["ModeChanger"]
 
 class ModeChanger(Processor):
-	'''Changes file modes'''
+    '''Changes file modes'''
 
-	input_variables = {
-		'filename': {
-			'required': True,
-			'description': 'Name of filename resource',
-		},
-		'mode': {
-			'required': True,
-			'description': 'chmod(1) mode string to apply to file. E.g. "o-w"'
-		},
-	}
-	output_variables = {
-	}
+    input_variables = {
+        'filename': {
+            'required': True,
+            'description': 'Name of filename resource',
+        },
+        'mode': {
+            'required': True,
+            'description': 'chmod(1) mode string to apply to file. E.g. "o-w"'
+        },
+    }
+    output_variables = {
+    }
 
-	def main(self):
-		filename = self.env.get('filename')
-		mode = self.env.get('mode')
+    def main(self):
+        filename = self.env.get('filename')
+        mode = self.env.get('mode')
 
-		retcode = subprocess.call(['/bin/chmod', mode, filename])
-		if retcode:
-			raise ProcessorError('Error setting mode (chmod %s) for %s' % (mode, filename))
+        retcode = subprocess.call(['/bin/chmod', mode, filename])
+        if retcode:
+            raise ProcessorError('Error setting mode (chmod %s) for %s' % (mode, filename))
 
-		return
+        return

--- a/Extensis/ModeChanger.py
+++ b/Extensis/ModeChanger.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
+
 import subprocess
-import os
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["ModeChanger"]
 

--- a/Extensis/ModeChanger.py
+++ b/Extensis/ModeChanger.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 import subprocess
 import os

--- a/GrandPerspective/SourceForgeURLProvider.py
+++ b/GrandPerspective/SourceForgeURLProvider.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import datetime
 import re
 from xml.dom.minidom import parse, parseString

--- a/GrandPerspective/SourceForgeURLProvider.py
+++ b/GrandPerspective/SourceForgeURLProvider.py
@@ -5,21 +5,16 @@ from __future__ import absolute_import
 import datetime
 import json
 import re
-from xml.dom.minidom import parse, parseString
+from xml.dom.minidom import parseString
 
-from autopkglib import Processor, ProcessorError
-
-try:
-    from urllib.request import urlopen  # For Python 3
-except ImportError:
-    from urllib2 import urlopen  # For Python 2
+from autopkglib import Processor, ProcessorError, URLGetter
 
 __all__ = ["SourceForgeURLProvider"]
 
 FILE_INDEX_URL = 'http://sourceforge.net/api/file/index/project-id/%s/rss'
 PROJECT_NAME_URL = 'https://sourceforge.net/rest/p/%s'
 
-class SourceForgeURLProvider(Processor):
+class SourceForgeURLProvider(URLGetter):
     '''Provides URL to the latest file that matches a pattern for a particular SourceForge project.'''
 
     input_variables = {
@@ -47,9 +42,7 @@ class SourceForgeURLProvider(Processor):
     def get_sf_project_id(self, pname):
         # borrowed from https://gist.github.com/homebysix/9468859a76ac82f1d121
         try:
-            f = urlopen(PROJECT_NAME_URL % pname)
-            raw_json = f.read()
-            f.close()
+            raw_json = self.download(PROJECT_NAME_URL % pname)
         except:
             raise ProcessorError('Could not retrieve project name URL for "%s"' % pname)
 
@@ -65,9 +58,7 @@ class SourceForgeURLProvider(Processor):
         flisturl = FILE_INDEX_URL % proj_id
 
         try:
-            f = urlopen(flisturl)
-            rss = f.read()
-            f.close()
+            rss = self.download(flisturl)
         except Exception as e:
             raise ProcessorError('Could not retrieve RSS feed %s' % flisturl)
 

--- a/GrandPerspective/SourceForgeURLProvider.py
+++ b/GrandPerspective/SourceForgeURLProvider.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+
 import datetime
+import json
 import re
 from xml.dom.minidom import parse, parseString
-import json
 
 from autopkglib import Processor, ProcessorError
 

--- a/GrandPerspective/SourceForgeURLProvider.py
+++ b/GrandPerspective/SourceForgeURLProvider.py
@@ -68,7 +68,7 @@ class SourceForgeURLProvider(Processor):
             f = urlopen(flisturl)
             rss = f.read()
             f.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError('Could not retrieve RSS feed %s' % flisturl)
 
         re_file = re.compile(self.env.get('SOURCEFORGE_FILE_PATTERN'), re.I)

--- a/GrandPerspective/SourceForgeURLProvider.py
+++ b/GrandPerspective/SourceForgeURLProvider.py
@@ -4,10 +4,14 @@ from __future__ import absolute_import
 import datetime
 import re
 from xml.dom.minidom import parse, parseString
-import urllib2
 import json
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["SourceForgeURLProvider"]
 
@@ -15,95 +19,95 @@ FILE_INDEX_URL = 'http://sourceforge.net/api/file/index/project-id/%s/rss'
 PROJECT_NAME_URL = 'https://sourceforge.net/rest/p/%s'
 
 class SourceForgeURLProvider(Processor):
-	'''Provides URL to the latest file that matches a pattern for a particular SourceForge project.'''
+    '''Provides URL to the latest file that matches a pattern for a particular SourceForge project.'''
 
-	input_variables = {
-		'SOURCEFORGE_PROJECT_NAME': {
-			'required': False,
-			'description': 'Numerical ID of SourceForge project. One of SOURCEFORGE_PROJECT_ID or SOURCEFORGE_PROJECT_NAME must be specified.',
-			},
-		'SOURCEFORGE_PROJECT_ID': {
-			'required': False,
-			'description': 'Numerical ID of SourceForge project. One of SOURCEFORGE_PROJECT_ID or SOURCEFORGE_PROJECT_NAME must be specified.',
-			},
-		'SOURCEFORGE_FILE_PATTERN': {
-			'required': True,
-			'description': 'Pattern to match SourceFile files on',
-			},
-	}
-	output_variables = {
-		'url': {
-			'description': 'URL to the latest SourceForge project download'
-		}
-	}
+    input_variables = {
+        'SOURCEFORGE_PROJECT_NAME': {
+            'required': False,
+            'description': 'Numerical ID of SourceForge project. One of SOURCEFORGE_PROJECT_ID or SOURCEFORGE_PROJECT_NAME must be specified.',
+            },
+        'SOURCEFORGE_PROJECT_ID': {
+            'required': False,
+            'description': 'Numerical ID of SourceForge project. One of SOURCEFORGE_PROJECT_ID or SOURCEFORGE_PROJECT_NAME must be specified.',
+            },
+        'SOURCEFORGE_FILE_PATTERN': {
+            'required': True,
+            'description': 'Pattern to match SourceFile files on',
+            },
+    }
+    output_variables = {
+        'url': {
+            'description': 'URL to the latest SourceForge project download'
+        }
+    }
 
-	description = __doc__
+    description = __doc__
 
-	def get_sf_project_id(self, pname):
-		# borrowed from https://gist.github.com/homebysix/9468859a76ac82f1d121
-		try:
-			f = urllib2.urlopen(PROJECT_NAME_URL % pname)
-			raw_json = f.read()
-			f.close()
-		except:
-			raise ProcessorError('Could not retrieve project name URL for "%s"' % pname)
+    def get_sf_project_id(self, pname):
+        # borrowed from https://gist.github.com/homebysix/9468859a76ac82f1d121
+        try:
+            f = urlopen(PROJECT_NAME_URL % pname)
+            raw_json = f.read()
+            f.close()
+        except:
+            raise ProcessorError('Could not retrieve project name URL for "%s"' % pname)
 
-		parsed_json = json.loads(raw_json)
+        parsed_json = json.loads(raw_json)
 
-		for tools in parsed_json['tools']:
-			try:
-				return tools['sourceforge_group_id']
-			except KeyError:
-				pass
+        for tools in parsed_json['tools']:
+            try:
+                return tools['sourceforge_group_id']
+            except KeyError:
+                pass
 
-	def get_sf_file_url(self, proj_id, pattern):
-		flisturl = FILE_INDEX_URL % proj_id
+    def get_sf_file_url(self, proj_id, pattern):
+        flisturl = FILE_INDEX_URL % proj_id
 
-		try:
-			f = urllib2.urlopen(flisturl)
-			rss = f.read()
-			f.close()
-		except BaseException as e:
-			raise ProcessorError('Could not retrieve RSS feed %s' % flisturl)
+        try:
+            f = urlopen(flisturl)
+            rss = f.read()
+            f.close()
+        except BaseException as e:
+            raise ProcessorError('Could not retrieve RSS feed %s' % flisturl)
 
-		re_file = re.compile(self.env.get('SOURCEFORGE_FILE_PATTERN'), re.I)
+        re_file = re.compile(self.env.get('SOURCEFORGE_FILE_PATTERN'), re.I)
 
-		rss_parse = parseString(rss)
+        rss_parse = parseString(rss)
 
-		items = []
+        items = []
 
-		for i in  rss_parse.getElementsByTagName('item'):
-			pubDate = i.getElementsByTagName('pubDate')[0].firstChild.nodeValue
-			link = i.getElementsByTagName('link')[0].firstChild.nodeValue
+        for i in  rss_parse.getElementsByTagName('item'):
+            pubDate = i.getElementsByTagName('pubDate')[0].firstChild.nodeValue
+            link = i.getElementsByTagName('link')[0].firstChild.nodeValue
 
-			pubDatetime = datetime.datetime.strptime(pubDate, '%a, %d %b %Y %H:%M:%S UT')
+            pubDatetime = datetime.datetime.strptime(pubDate, '%a, %d %b %Y %H:%M:%S UT')
 
-			if re_file.search(link):
-				items.append((pubDatetime, link),)
+            if re_file.search(link):
+                items.append((pubDatetime, link),)
 
-		items.sort(key=lambda r: r[0])
+        items.sort(key=lambda r: r[0])
 
-		if len(items) < 1:
-			raise ProcessorError('No matched files')
+        if len(items) < 1:
+            raise ProcessorError('No matched files')
 
-		return items[-1][1]
+        return items[-1][1]
 
-	def main(self):
-		proj_name = self.env.get('SOURCEFORGE_PROJECT_NAME')
-		proj_id  = self.env.get('SOURCEFORGE_PROJECT_ID')
-		file_pat = self.env.get('SOURCEFORGE_FILE_PATTERN')
+    def main(self):
+        proj_name = self.env.get('SOURCEFORGE_PROJECT_NAME')
+        proj_id  = self.env.get('SOURCEFORGE_PROJECT_ID')
+        file_pat = self.env.get('SOURCEFORGE_FILE_PATTERN')
 
-		if not proj_id:
-			if not proj_name:
-				raise ProcessorError('One of SOURCEFORGE_PROJECT_ID or SOURCEFORGE_PROJECT_NAME must be specified.')
+        if not proj_id:
+            if not proj_name:
+                raise ProcessorError('One of SOURCEFORGE_PROJECT_ID or SOURCEFORGE_PROJECT_NAME must be specified.')
 
-			proj_id = self.get_sf_project_id(proj_name)
-			self.output('Found SourceForge project ID %s for %s' % (proj_id, proj_name))
+            proj_id = self.get_sf_project_id(proj_name)
+            self.output('Found SourceForge project ID %s for %s' % (proj_id, proj_name))
 
 
-		self.env['url'] = self.get_sf_file_url(proj_id, file_pat)
-		self.output('File URL %s' % self.env['url'])
+        self.env['url'] = self.get_sf_file_url(proj_id, file_pat)
+        self.output('File URL %s' % self.env['url'])
 
 if __name__ == '__main__':
-	processor = SourceForgeURLProvider()
-	processor.execute_shell()
+    processor = SourceForgeURLProvider()
+    processor.execute_shell()

--- a/LoginScriptPlugin/LoginScriptPluginUninstallCreator.py
+++ b/LoginScriptPlugin/LoginScriptPluginUninstallCreator.py
@@ -2,24 +2,24 @@
 #
 # Copyright 2016 Jesse Peterson
 #
-#        DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE 
-#                    Version 2, December 2004 
+#        DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+#                    Version 2, December 2004
 #
-# Copyright (C) 2004 Sam Hocevar <sam@hocevar.net> 
+# Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
 #
-# Everyone is permitted to copy and distribute verbatim or modified 
-# copies of this license document, and changing it is allowed as long 
-# as the name is changed. 
+# Everyone is permitted to copy and distribute verbatim or modified
+# copies of this license document, and changing it is allowed as long
+# as the name is changed.
 #
-#            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE 
-#   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION 
+#            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+#   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 #
 #  0. You just DO WHAT THE FUCK YOU WANT TO.
 #
 """See docstring for LoginScriptPluginUninstallCreator class"""
 
 from __future__ import absolute_import
-from os import rename
+
 from autopkglib import Processor
 
 __all__ = ["LoginScriptPluginUninstallCreator"]

--- a/LoginScriptPlugin/LoginScriptPluginUninstallCreator.py
+++ b/LoginScriptPlugin/LoginScriptPluginUninstallCreator.py
@@ -18,6 +18,7 @@
 #
 """See docstring for LoginScriptPluginUninstallCreator class"""
 
+from __future__ import absolute_import
 from os import rename
 from autopkglib import Processor
 

--- a/NVIDIA/CUDADriverURLProvider.py
+++ b/NVIDIA/CUDADriverURLProvider.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 import os
 import subprocess
 
-from autopkglib import Processor, ProcessorError
-
-from Foundation import NSPredicate
 import FoundationPlist
+from autopkglib import Processor, ProcessorError
+from Foundation import NSPredicate
 
 __all__ = ["CUDADriverURLProvider"]
 

--- a/NVIDIA/CUDADriverURLProvider.py
+++ b/NVIDIA/CUDADriverURLProvider.py
@@ -16,98 +16,98 @@ CHECK_URL = 'https://partners.download.nvidia.com/activation/cuda_update_macos.x
 PLIST_FN  = 'cuda_update_macos.plist'
 
 class CUDADriverURLProvider(Processor):
-	'''Provides URL to the latest CUDA Driver download from NVIDIA.'''
+    '''Provides URL to the latest CUDA Driver download from NVIDIA.'''
 
-	input_variables = {
-		'cuda_os_ver': {
-			'required': False,
-			'description': 'Version of OS to test the CUDA update NSPredicate with. Defaults to currently shipping Apple Mac OS X version.',
-			},
-	}
-	output_variables = {
-		'minimum_os_version': {
-			'description': 'Minimum OS version requirement of the Driver DMG download.'
-		},
-		'version': {
-			'description': 'Version of CUDA Driver DMG download.'
-		},
-		'url': {
-			'description': 'URL to the latest CUDA Driver DMG download.'
-		},
-	}
+    input_variables = {
+        'cuda_os_ver': {
+            'required': False,
+            'description': 'Version of OS to test the CUDA update NSPredicate with. Defaults to currently shipping Apple Mac OS X version.',
+            },
+    }
+    output_variables = {
+        'minimum_os_version': {
+            'description': 'Minimum OS version requirement of the Driver DMG download.'
+        },
+        'version': {
+            'description': 'Version of CUDA Driver DMG download.'
+        },
+        'url': {
+            'description': 'URL to the latest CUDA Driver DMG download.'
+        },
+    }
 
-	description = __doc__
+    description = __doc__
 
-	def evaluate_predicate(self, eval_obj, predicate_str):
-		try:
-			predicate = NSPredicate.predicateWithFormat_(predicate_str)
-		except:
-			raise ProcessorError('Problem with NSPredicate: %s' % rule['Predicate'])
-		return predicate.evaluateWithObject_(eval_obj)
-
-
-	def get_url(self, os_ver):
-		try:
-			plist_text = subprocess.check_output(['/usr/bin/curl', '-s', '-1', CHECK_URL])
-		except BaseException as e:
-			print(e)
-			raise ProcessorError('Could not retrieve check URL %s' % CHECK_URL)
-
-		plist_filename = os.path.join(self.env['RECIPE_CACHE_DIR'], PLIST_FN)
-
-		try:
-			plistf = open(plist_filename, 'w')
-			plistf.write(plist_text)
-			plistf.close()
-		except:
-			raise ProcessorError('Could not write NVIDIA plist file %s' % plist_filename)
-
-		try:
-			plist = FoundationPlist.readPlist(plist_filename)
-		except:
-			raise ProcessorError('Could not read NVIDIA plist file %s' % plist_filename)
-
-		# the Version is blank here due to the plist NSPredicate
-		# testing it to not be the current version.
-		pred_obj = {'Ticket': {'Version': ''}, 'SystemVersion': {'ProductVersion': os_ver}}
-
-		url = None
-		version = None
-		for rule in plist['Rules']:
-			if self.evaluate_predicate(pred_obj, rule['Predicate']):
-				self.output('Satisfied predicate for OS version %s' % os_ver)
-				url = rule['Codebase']
-				version = rule['kServerVersion']
-
-				# with a satisfied predicate, evaluate lower OS versions
-				# so as to determine a minimum OS constraint, decrementing
-				# one 10.x version at a time
-				while self.evaluate_predicate(pred_obj, rule['Predicate']):
-					# record the currently-evaluated OS version as the minimum required
-					minimum_os_ver = os_ver
-					osx, major = os_ver.split('.')
-					os_ver = osx + '.' + str(int(major) - 1)
-					pred_obj['SystemVersion']['ProductVersion'] = os_ver
-					self.output('Evaluating predicate for lower OS version %s' % os_ver)
-				self.output('OS version %s too low!' % os_ver)
-				# highest required versions seem to be always first, so we break
-				# after we've satisfied one Predicate
-				break
+    def evaluate_predicate(self, eval_obj, predicate_str):
+        try:
+            predicate = NSPredicate.predicateWithFormat_(predicate_str)
+        except:
+            raise ProcessorError('Problem with NSPredicate: %s' % rule['Predicate'])
+        return predicate.evaluateWithObject_(eval_obj)
 
 
-		if not url:
-			raise ProcessorError('No valid Predicate rules found!')
-		return (url, version, minimum_os_ver)
+    def get_url(self, os_ver):
+        try:
+            plist_text = subprocess.check_output(['/usr/bin/curl', '-s', '-1', CHECK_URL])
+        except BaseException as e:
+            print(e)
+            raise ProcessorError('Could not retrieve check URL %s' % CHECK_URL)
 
-	def main(self):
-		if 'cuda_os_ver' in self.env:
-			cuda_os_ver = self.env['cuda_os_ver']
-		else:
-			cuda_os_ver = '10.10'
+        plist_filename = os.path.join(self.env['RECIPE_CACHE_DIR'], PLIST_FN)
 
-		self.env['url'], self.env['version'], self.env['minimum_os_version'] = self.get_url(cuda_os_ver)
-		self.output('File URL %s, Version number %s' % (self.env['url'], self.env['version']))
+        try:
+            plistf = open(plist_filename, 'w')
+            plistf.write(plist_text)
+            plistf.close()
+        except:
+            raise ProcessorError('Could not write NVIDIA plist file %s' % plist_filename)
+
+        try:
+            plist = FoundationPlist.readPlist(plist_filename)
+        except:
+            raise ProcessorError('Could not read NVIDIA plist file %s' % plist_filename)
+
+        # the Version is blank here due to the plist NSPredicate
+        # testing it to not be the current version.
+        pred_obj = {'Ticket': {'Version': ''}, 'SystemVersion': {'ProductVersion': os_ver}}
+
+        url = None
+        version = None
+        for rule in plist['Rules']:
+            if self.evaluate_predicate(pred_obj, rule['Predicate']):
+                self.output('Satisfied predicate for OS version %s' % os_ver)
+                url = rule['Codebase']
+                version = rule['kServerVersion']
+
+                # with a satisfied predicate, evaluate lower OS versions
+                # so as to determine a minimum OS constraint, decrementing
+                # one 10.x version at a time
+                while self.evaluate_predicate(pred_obj, rule['Predicate']):
+                    # record the currently-evaluated OS version as the minimum required
+                    minimum_os_ver = os_ver
+                    osx, major = os_ver.split('.')
+                    os_ver = osx + '.' + str(int(major) - 1)
+                    pred_obj['SystemVersion']['ProductVersion'] = os_ver
+                    self.output('Evaluating predicate for lower OS version %s' % os_ver)
+                self.output('OS version %s too low!' % os_ver)
+                # highest required versions seem to be always first, so we break
+                # after we've satisfied one Predicate
+                break
+
+
+        if not url:
+            raise ProcessorError('No valid Predicate rules found!')
+        return (url, version, minimum_os_ver)
+
+    def main(self):
+        if 'cuda_os_ver' in self.env:
+            cuda_os_ver = self.env['cuda_os_ver']
+        else:
+            cuda_os_ver = '10.10'
+
+        self.env['url'], self.env['version'], self.env['minimum_os_version'] = self.get_url(cuda_os_ver)
+        self.output('File URL %s, Version number %s' % (self.env['url'], self.env['version']))
 
 if __name__ == '__main__':
-	processor = CUDADriverURLProvider()
-	processor.execute_shell()
+    processor = CUDADriverURLProvider()
+    processor.execute_shell()

--- a/NVIDIA/CUDADriverURLProvider.py
+++ b/NVIDIA/CUDADriverURLProvider.py
@@ -20,8 +20,10 @@ class CUDADriverURLProvider(Processor):
     input_variables = {
         'cuda_os_ver': {
             'required': False,
-            'description': 'Version of OS to test the CUDA update NSPredicate with. Defaults to currently shipping Apple Mac OS X version.',
-            },
+            'default': '10.14',
+            'description': 'Version of OS to test the CUDA update '
+                           'NSPredicate with. Defaults to 10.14.',
+        },
     }
     output_variables = {
         'minimum_os_version': {

--- a/NVIDIA/CUDADriverURLProvider.py
+++ b/NVIDIA/CUDADriverURLProvider.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import subprocess
 
@@ -48,7 +50,7 @@ class CUDADriverURLProvider(Processor):
 		try:
 			plist_text = subprocess.check_output(['/usr/bin/curl', '-s', '-1', CHECK_URL])
 		except BaseException as e:
-			print e
+			print(e)
 			raise ProcessorError('Could not retrieve check URL %s' % CHECK_URL)
 
 		plist_filename = os.path.join(self.env['RECIPE_CACHE_DIR'], PLIST_FN)

--- a/NVIDIA/CUDADriverURLProvider.py
+++ b/NVIDIA/CUDADriverURLProvider.py
@@ -43,7 +43,7 @@ class CUDADriverURLProvider(Processor):
         try:
             predicate = NSPredicate.predicateWithFormat_(predicate_str)
         except:
-            raise ProcessorError('Problem with NSPredicate: %s' % rule['Predicate'])
+            raise ProcessorError('Problem with NSPredicate: %s' % predicate_str)
         return predicate.evaluateWithObject_(eval_obj)
 
 

--- a/NVIDIA/CUDADriverURLProvider.py
+++ b/NVIDIA/CUDADriverURLProvider.py
@@ -48,7 +48,7 @@ class CUDADriverURLProvider(Processor):
     def get_url(self, os_ver):
         try:
             plist_text = subprocess.check_output(['/usr/bin/curl', '-s', '-1', CHECK_URL])
-        except BaseException as e:
+        except Exception as e:
             print(e)
             raise ProcessorError('Could not retrieve check URL %s' % CHECK_URL)
 

--- a/Oracle/VirtualBoxURLProvider.py
+++ b/Oracle/VirtualBoxURLProvider.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+
 import re
 
 from autopkglib import Processor, ProcessorError

--- a/Oracle/VirtualBoxURLProvider.py
+++ b/Oracle/VirtualBoxURLProvider.py
@@ -22,8 +22,8 @@ UPDATE_CHECK_URL = 'https://update.virtualbox.org/query.php?platform=DARWIN_64BI
 ROOT_URL = 'http://download.virtualbox.org/virtualbox'
 LATEST_URL = ROOT_URL + '/LATEST.TXT'
 
-re_vbox = re.compile('(VirtualBox-([0-9\.]*)-[0-9]*-OSX\.dmg)')
-re_ext = re.compile('(Oracle_VM_VirtualBox_Extension_Pack-[0-9\.]*-[0-9]*\.vbox-extpack)')
+re_vbox = re.compile(r'(VirtualBox-([0-9\.]*)-[0-9]*-OSX\.dmg)')
+re_ext = re.compile(r'(Oracle_VM_VirtualBox_Extension_Pack-[0-9\.]*-[0-9]*\.vbox-extpack)')
 
 class VirtualBoxURLProvider(Processor):
     '''Provides URL to the latest VirtualBox version.'''

--- a/Oracle/VirtualBoxURLProvider.py
+++ b/Oracle/VirtualBoxURLProvider.py
@@ -49,7 +49,7 @@ class VirtualBoxURLProvider(Processor):
             f = urlopen(LATEST_URL)
             latest = f.readline().rstrip()
             f.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError('Could not retrieve URL: %s' % LATEST_URL)
 
         # lame! use RE some day
@@ -74,7 +74,7 @@ class VirtualBoxURLProvider(Processor):
             f = urlopen(UPDATE_CHECK_URL)
             latest = f.readline()
             f.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError('Could not retrieve URL: %s' % LATEST_URL)
 
         upd_url = latest.split(' ', 1)[1]
@@ -94,7 +94,7 @@ class VirtualBoxURLProvider(Processor):
             f = urlopen(md5_url)
             md5sums = f.read()
             f.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError('Could not retrieve URL: %s' % md5_url)
 
         m = re_vbox.search(md5sums)

--- a/Oracle/VirtualBoxURLProvider.py
+++ b/Oracle/VirtualBoxURLProvider.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import datetime
 import re
 import urllib2

--- a/Oracle/VirtualBoxURLProvider.py
+++ b/Oracle/VirtualBoxURLProvider.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-import datetime
 import re
-import urllib2
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["VirtualBoxURLProvider"]
 
@@ -22,101 +25,101 @@ re_vbox = re.compile('(VirtualBox-([0-9\.]*)-[0-9]*-OSX\.dmg)')
 re_ext = re.compile('(Oracle_VM_VirtualBox_Extension_Pack-[0-9\.]*-[0-9]*\.vbox-extpack)')
 
 class VirtualBoxURLProvider(Processor):
-	'''Provides URL to the latest VirtualBox version.'''
+    '''Provides URL to the latest VirtualBox version.'''
 
-	input_variables = {}
-	output_variables = {
-		'virtualbox_version': {
-			'description': 'Version of VirtualBox release'
-		},
-		'virtualbox_url': {
-			'description': 'URL to the latest Universal Type Client 3 download'
-		},
-		'extpack_url': {
-			'description': 'URL to the latest Universal Type Client 3 download'
-		},
+    input_variables = {}
+    output_variables = {
+        'virtualbox_version': {
+            'description': 'Version of VirtualBox release'
+        },
+        'virtualbox_url': {
+            'description': 'URL to the latest Universal Type Client 3 download'
+        },
+        'extpack_url': {
+            'description': 'URL to the latest Universal Type Client 3 download'
+        },
 
-	}
+    }
 
-	description = __doc__
+    description = __doc__
 
-	def get_latest_file(self):
-		try:
-			f = urllib2.urlopen(LATEST_URL)
-			latest = f.readline().rstrip()
-			f.close()
-		except BaseException as e:
-			raise ProcessorError('Could not retrieve URL: %s' % LATEST_URL)
+    def get_latest_file(self):
+        try:
+            f = urlopen(LATEST_URL)
+            latest = f.readline().rstrip()
+            f.close()
+        except BaseException as e:
+            raise ProcessorError('Could not retrieve URL: %s' % LATEST_URL)
 
-		# lame! use RE some day
-		if '.' not in latest:
-			raise ProcessorError('Not a valid VirtualBox version: %s' % latest)
+        # lame! use RE some day
+        if '.' not in latest:
+            raise ProcessorError('Not a valid VirtualBox version: %s' % latest)
 
-		return latest
+        return latest
 
-	def get_latest(self):
-		'''Retrieve update check URL, parse, and return the current version
-		number of the current VirtualBox. E.g. "4.23.16"
+    def get_latest(self):
+        '''Retrieve update check URL, parse, and return the current version
+        number of the current VirtualBox. E.g. "4.23.16"
 
-		The update check URL reply body seems to be one line with a version
-		number and URL separated by a space character. In the first iteration
-		of this Processor the first space-seperated parameter was the current
-		version of VirtualBox. Somewhere in May 2015 this started returning
-		a beta release number (5.0.0_BETA4) instead of the current version.
-		So instead of using that first parameter attempt to parse out the
-		version number from the second parameter which apparently is still
-		the correct and current stable release URL.'''
-		try:
-			f = urllib2.urlopen(UPDATE_CHECK_URL)
-			latest = f.readline()
-			f.close()
-		except BaseException as e:
-			raise ProcessorError('Could not retrieve URL: %s' % LATEST_URL)
+        The update check URL reply body seems to be one line with a version
+        number and URL separated by a space character. In the first iteration
+        of this Processor the first space-seperated parameter was the current
+        version of VirtualBox. Somewhere in May 2015 this started returning
+        a beta release number (5.0.0_BETA4) instead of the current version.
+        So instead of using that first parameter attempt to parse out the
+        version number from the second parameter which apparently is still
+        the correct and current stable release URL.'''
+        try:
+            f = urlopen(UPDATE_CHECK_URL)
+            latest = f.readline()
+            f.close()
+        except BaseException as e:
+            raise ProcessorError('Could not retrieve URL: %s' % LATEST_URL)
 
-		upd_url = latest.split(' ', 1)[1]
+        upd_url = latest.split(' ', 1)[1]
 
-		m = re_vbox.search(upd_url)
-		if m:
-			vb_ver = m.group(2)
-		else:
-			raise ProcessorError('No matching VirtualBox URL')
+        m = re_vbox.search(upd_url)
+        if m:
+            vb_ver = m.group(2)
+        else:
+            raise ProcessorError('No matching VirtualBox URL')
 
-		return vb_ver
+        return vb_ver
 
-	def get_urls(self, version):
-		md5_url = '/'.join((ROOT_URL, version, 'MD5SUMS', ))
+    def get_urls(self, version):
+        md5_url = '/'.join((ROOT_URL, version, 'MD5SUMS', ))
 
-		try:
-			f = urllib2.urlopen(md5_url)
-			md5sums = f.read()
-			f.close()
-		except BaseException as e:
-			raise ProcessorError('Could not retrieve URL: %s' % md5_url)
+        try:
+            f = urlopen(md5_url)
+            md5sums = f.read()
+            f.close()
+        except BaseException as e:
+            raise ProcessorError('Could not retrieve URL: %s' % md5_url)
 
-		m = re_vbox.search(md5sums)
-		if m:
-			vb_url = '/'.join((ROOT_URL, version, m.group(1), ))
-		else:
-			raise ProcessorError('No matching VirtualBox software')
+        m = re_vbox.search(md5sums)
+        if m:
+            vb_url = '/'.join((ROOT_URL, version, m.group(1), ))
+        else:
+            raise ProcessorError('No matching VirtualBox software')
 
-		m = re_ext.search(md5sums)
-		if m:
-			ext_url = '/'.join((ROOT_URL, version, m.group(1), ))
-		else:
-			raise ProcessorError('No matching VirtualBox Ext. Pack software')
+        m = re_ext.search(md5sums)
+        if m:
+            ext_url = '/'.join((ROOT_URL, version, m.group(1), ))
+        else:
+            raise ProcessorError('No matching VirtualBox Ext. Pack software')
 
-		return (vb_url, ext_url, )
+        return (vb_url, ext_url, )
 
-	def main(self):
-		self.env['virtualbox_version'] = self.get_latest_file()
-		self.output('Latest is %s' % self.env['virtualbox_version'])
+    def main(self):
+        self.env['virtualbox_version'] = self.get_latest_file()
+        self.output('Latest is %s' % self.env['virtualbox_version'])
 
-		self.env['virtualbox_url'], self.env['extpack_url'] = \
-			self.get_urls(self.env['virtualbox_version'])
+        self.env['virtualbox_url'], self.env['extpack_url'] = \
+            self.get_urls(self.env['virtualbox_version'])
 
-		self.output('VirtualBox URL: %s' % self.env['virtualbox_url'])
-		self.output('Ext. pack  URL: %s' % self.env['extpack_url'])
+        self.output('VirtualBox URL: %s' % self.env['virtualbox_url'])
+        self.output('Ext. pack  URL: %s' % self.env['extpack_url'])
 
 if __name__ == '__main__':
-	processor = VirtualBoxURLProvider()
-	processor.execute_shell()
+    processor = VirtualBoxURLProvider()
+    processor.execute_shell()

--- a/PredicateInstaller/TimestampVersioner.py
+++ b/PredicateInstaller/TimestampVersioner.py
@@ -10,32 +10,32 @@ from autopkglib import Processor, ProcessorError
 __all__ = ["TimestampVersioner"]
 
 class TimestampVersioner(Processor):
-	'''Returns a version of the current'''
+    '''Returns a version of the current'''
 
-	input_variables = {
-		'version_major': {
-			'description': 'Major component of version',
-			'required': False,
-		}
-	}
-	output_variables = {
-		'version': {
-			'description': 'Pseudo-version of the format <maj>.<min>. Maj is default 0 and min is the current epoch time.'
-		},
-	}
+    input_variables = {
+        'version_major': {
+            'description': 'Major component of version',
+            'required': False,
+        }
+    }
+    output_variables = {
+        'version': {
+            'description': 'Pseudo-version of the format <maj>.<min>. Maj is default 0 and min is the current epoch time.'
+        },
+    }
 
-	description = __doc__
+    description = __doc__
 
-	def main(self):
-		vmaj = self.env.get('version_major', '0')
-		vmin = int(time())
+    def main(self):
+        vmaj = self.env.get('version_major', '0')
+        vmin = int(time())
 
-		version = '%s.%d' % (vmaj, vmin)
+        version = '%s.%d' % (vmaj, vmin)
 
-		self.output('Version is %s' % version)
+        self.output('Version is %s' % version)
 
-		self.env['version'] = version
+        self.env['version'] = version
 
 if __name__ == '__main__':
-	processor = TimestampVersioner()
-	processor.execute_shell()
+    processor = TimestampVersioner()
+    processor.execute_shell()

--- a/PredicateInstaller/TimestampVersioner.py
+++ b/PredicateInstaller/TimestampVersioner.py
@@ -3,6 +3,7 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+
 from time import time
 
 from autopkglib import Processor, ProcessorError

--- a/PredicateInstaller/TimestampVersioner.py
+++ b/PredicateInstaller/TimestampVersioner.py
@@ -2,6 +2,7 @@
 
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 from time import time
 
 from autopkglib import Processor, ProcessorError

--- a/TrueCrypt/TrueCryptURLProvider.py
+++ b/TrueCrypt/TrueCryptURLProvider.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import re
 import urllib
 import urllib2

--- a/TrueCrypt/TrueCryptURLProvider.py
+++ b/TrueCrypt/TrueCryptURLProvider.py
@@ -21,7 +21,7 @@ __all__ = ["TrueCryptURLProvider"]
 
 DLV_URL = 'http://www.truecrypt.org/downloads'
 DLS_URL = 'http://www.truecrypt.org/dl'
-re_verfind = re.compile('<input type="hidden" name="DownloadVersion" value="([0-9A-Za-z\.]*)">')
+re_verfind = re.compile(r'<input type="hidden" name="DownloadVersion" value="([0-9A-Za-z\.]*)">')
 
 class TrueCryptURLProvider(Processor):
     '''Provides URL to the latest TrueCrypt installer DMG.'''

--- a/TrueCrypt/TrueCryptURLProvider.py
+++ b/TrueCrypt/TrueCryptURLProvider.py
@@ -2,10 +2,14 @@
 
 from __future__ import absolute_import
 import re
-import urllib
 import urllib2
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib import request as urllib  # For Python 3
+except ImportError:
+    import urllib  # For Python 2
 
 __all__ = ["TrueCryptURLProvider"]
 

--- a/TrueCrypt/TrueCryptURLProvider.py
+++ b/TrueCrypt/TrueCryptURLProvider.py
@@ -44,7 +44,7 @@ class TrueCryptURLProvider(Processor):
             f = urllib2.urlopen(DLV_URL)
             content = f.read()
             f.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError('Could not retrieve URL: %s' % DLV_URL)
 
         m = re_verfind.search(content)
@@ -80,7 +80,7 @@ class TrueCryptURLProvider(Processor):
             f = opener.open(req)
             content = f.read()
             f.close()
-        except BaseException as e:
+        except Exception as e:
             if isinstance(e, urllib2.HTTPError) and e.code == 302:
                 url = e.headers['Location']
             else:

--- a/TrueCrypt/TrueCryptURLProvider.py
+++ b/TrueCrypt/TrueCryptURLProvider.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+
 import re
 import urllib2
 

--- a/TrueCrypt/TrueCryptURLProvider.py
+++ b/TrueCrypt/TrueCryptURLProvider.py
@@ -18,83 +18,83 @@ DLS_URL = 'http://www.truecrypt.org/dl'
 re_verfind = re.compile('<input type="hidden" name="DownloadVersion" value="([0-9A-Za-z\.]*)">')
 
 class TrueCryptURLProvider(Processor):
-	'''Provides URL to the latest TrueCrypt installer DMG.'''
+    '''Provides URL to the latest TrueCrypt installer DMG.'''
 
-	input_variables = {
-	}
-	output_variables = {
-		'url': {
-			'description': 'URL to the latest download',
-		},
-		'truecrypt_version': {
-			'description': 'Version number',
-		}
-	}
+    input_variables = {
+    }
+    output_variables = {
+        'url': {
+            'description': 'URL to the latest download',
+        },
+        'truecrypt_version': {
+            'description': 'Version number',
+        }
+    }
 
-	description = __doc__
+    description = __doc__
 
-	def get_version(self):
-		try:
-			f = urllib2.urlopen(DLV_URL)
-			content = f.read()
-			f.close()
-		except BaseException as e:
-			raise ProcessorError('Could not retrieve URL: %s' % DLV_URL)
+    def get_version(self):
+        try:
+            f = urllib2.urlopen(DLV_URL)
+            content = f.read()
+            f.close()
+        except BaseException as e:
+            raise ProcessorError('Could not retrieve URL: %s' % DLV_URL)
 
-		m = re_verfind.search(content)
+        m = re_verfind.search(content)
 
-		if m:
-			return m.group(1)
+        if m:
+            return m.group(1)
 
-		raise ProcessorError('No version found')
+        raise ProcessorError('No version found')
 
-	def get_url(self, version):
-		'''Get the URL of the TrueCrypt DMG
+    def get_url(self, version):
+        '''Get the URL of the TrueCrypt DMG
 
-		The TrueCrypt website has an HTML form that, when POSTed, returns
-		a 302 redirect to the actual DMG download. Handle all of that, as
-		ugly as it is, using urllib2.
-		'''
+        The TrueCrypt website has an HTML form that, when POSTed, returns
+        a 302 redirect to the actual DMG download. Handle all of that, as
+        ugly as it is, using urllib2.
+        '''
 
-		# no easy way to *not* follow redirects with urllib2, so do this
-		class NoRedirectHandler(urllib2.HTTPRedirectHandler):
-			def redirect_request(self, req, fp, code, msg, hdrs, newurl):
-				pass
+        # no easy way to *not* follow redirects with urllib2, so do this
+        class NoRedirectHandler(urllib2.HTTPRedirectHandler):
+            def redirect_request(self, req, fp, code, msg, hdrs, newurl):
+                pass
 
-		submit_form = {
-			'DownloadVersion': version,
-			'MacOSXDownload': 'Download',
-		}
+        submit_form = {
+            'DownloadVersion': version,
+            'MacOSXDownload': 'Download',
+        }
 
-		try:
-			req = urllib2.Request(DLS_URL, urllib.urlencode(submit_form))
+        try:
+            req = urllib2.Request(DLS_URL, urllib.urlencode(submit_form))
 
-			opener = urllib2.build_opener(NoRedirectHandler)
+            opener = urllib2.build_opener(NoRedirectHandler)
 
-			f = opener.open(req)
-			content = f.read()
-			f.close()
-		except BaseException as e:
-			if isinstance(e, urllib2.HTTPError) and e.code == 302:
-				url = e.headers['Location']
-			else:
-				raise ProcessorError('Could not retrieve URL: %s' % DLS_URL)
+            f = opener.open(req)
+            content = f.read()
+            f.close()
+        except BaseException as e:
+            if isinstance(e, urllib2.HTTPError) and e.code == 302:
+                url = e.headers['Location']
+            else:
+                raise ProcessorError('Could not retrieve URL: %s' % DLS_URL)
 
-		# hack to re-assemble URL with urlencoded filename part
-		url_split = url.split('/')
-		new_url = '/'.join(url_split[0:3]) + '/'
-		new_url += urllib.pathname2url('/'.join(url_split[3:]))
+        # hack to re-assemble URL with urlencoded filename part
+        url_split = url.split('/')
+        new_url = '/'.join(url_split[0:3]) + '/'
+        new_url += urllib.pathname2url('/'.join(url_split[3:]))
 
-		return new_url
+        return new_url
 
 
-	def main(self):
-		self.env['truecrypt_version'] = self.get_version()
-		self.output('Version: %s' % self.env['truecrypt_version'])
+    def main(self):
+        self.env['truecrypt_version'] = self.get_version()
+        self.output('Version: %s' % self.env['truecrypt_version'])
 
-		self.env['url'] = self.get_url(self.env['truecrypt_version'])
-		self.output('URL: %s' % self.env['url'])
+        self.env['url'] = self.get_url(self.env['truecrypt_version'])
+        self.output('URL: %s' % self.env['url'])
 
 if __name__ == '__main__':
-	processor = TrueCryptURLProvider()
-	processor.execute_shell()
+    processor = TrueCryptURLProvider()
+    processor.execute_shell()

--- a/TrueCrypt/TrueCryptURLProvider.py
+++ b/TrueCrypt/TrueCryptURLProvider.py
@@ -7,9 +7,14 @@ import urllib2
 from autopkglib import Processor, ProcessorError
 
 try:
-    from urllib import request as urllib  # For Python 3
+    from urllib.parse import urlencode  # For Python 3
 except ImportError:
-    import urllib  # For Python 2
+    from urllib import urlencode  # For Python 2
+
+try:
+    from urllib.request import pathname2url  # For Python 3
+except ImportError:
+    from urllib import pathname2url  # For Python 2
 
 __all__ = ["TrueCryptURLProvider"]
 
@@ -67,7 +72,7 @@ class TrueCryptURLProvider(Processor):
         }
 
         try:
-            req = urllib2.Request(DLS_URL, urllib.urlencode(submit_form))
+            req = urllib2.Request(DLS_URL, urlencode(submit_form))
 
             opener = urllib2.build_opener(NoRedirectHandler)
 
@@ -83,7 +88,7 @@ class TrueCryptURLProvider(Processor):
         # hack to re-assemble URL with urlencoded filename part
         url_split = url.split('/')
         new_url = '/'.join(url_split[0:3]) + '/'
-        new_url += urllib.pathname2url('/'.join(url_split[3:]))
+        new_url += pathname2url('/'.join(url_split[3:]))
 
         return new_url
 

--- a/VMware/ImageConverter.py
+++ b/VMware/ImageConverter.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-import subprocess
+
 import os
+import subprocess
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["ImageConverter"]

--- a/VMware/ImageConverter.py
+++ b/VMware/ImageConverter.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import subprocess
 import os
 from autopkglib import Processor, ProcessorError

--- a/VMware/VMwareToolsURLProvider.py
+++ b/VMware/VMwareToolsURLProvider.py
@@ -42,7 +42,7 @@ class VMwareToolsURLProvider(Processor):
         except BaseException as e:
             raise ProcessorError('Could not retrieve XML feed %s' % fusion_url)
 
-        build_re = re.compile('^fusion\/([\d\.]+)\/(\d+)\/')
+        build_re = re.compile(r'^fusion\/([\d\.]+)\/(\d+)\/')
 
         last_build_no = 0
         last_url_part = None

--- a/VMware/VMwareToolsURLProvider.py
+++ b/VMware/VMwareToolsURLProvider.py
@@ -39,7 +39,7 @@ class VMwareToolsURLProvider(Processor):
             f = urlopen(fusion_url)
             fusion_xml = f.read()
             f.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError('Could not retrieve XML feed %s' % fusion_url)
 
         build_re = re.compile(r'^fusion\/([\d\.]+)\/(\d+)\/')

--- a/VMware/VMwareToolsURLProvider.py
+++ b/VMware/VMwareToolsURLProvider.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+
 import re
-from xml.dom.minidom import parse, parseString
+from xml.dom.minidom import parseString
 
 from autopkglib import Processor, ProcessorError
 

--- a/VMware/VMwareToolsURLProvider.py
+++ b/VMware/VMwareToolsURLProvider.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import re
 from xml.dom.minidom import parse, parseString
 import urllib2

--- a/VMware/VMwareToolsURLProvider.py
+++ b/VMware/VMwareToolsURLProvider.py
@@ -3,9 +3,13 @@
 from __future__ import absolute_import
 import re
 from xml.dom.minidom import parse, parseString
-import urllib2
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["VMwareToolsURLProvider"]
 
@@ -14,64 +18,64 @@ DARWIN_TOOLS_URL_APPEND = 'packages/com.vmware.fusion.tools.darwin.zip.tar'
 DEFAULT_VERSION_SERIES = '11.0.0'
 
 class VMwareToolsURLProvider(Processor):
-	'''Provides URL to the latest Darwin ISO of the VMware Fusion tools.'''
+    '''Provides URL to the latest Darwin ISO of the VMware Fusion tools.'''
 
-	input_variables = {
-		'VERSION_SERIES': {
-			'required': False,
-			'description': 'Version of VMware Fusion to target tools of. E.g. "10.0.0". Defaults to "10.0.0"',
-			},
-	}
-	output_variables = {
-		'url': {
-			'description': 'URL to the latest SourceForge project download'
-		}
-	}
+    input_variables = {
+        'VERSION_SERIES': {
+            'required': False,
+            'description': 'Version of VMware Fusion to target tools of. E.g. "10.0.0". Defaults to "10.0.0"',
+            },
+    }
+    output_variables = {
+        'url': {
+            'description': 'URL to the latest SourceForge project download'
+        }
+    }
 
-	def get_url(self, version_series):
-		try:
-			fusion_url = FUSION_URL_BASE + '/fusion.xml'
-			f = urllib2.urlopen(fusion_url)
-			fusion_xml = f.read()
-			f.close()
-		except BaseException as e:
-			raise ProcessorError('Could not retrieve XML feed %s' % fusion_url)
+    def get_url(self, version_series):
+        try:
+            fusion_url = FUSION_URL_BASE + '/fusion.xml'
+            f = urlopen(fusion_url)
+            fusion_xml = f.read()
+            f.close()
+        except BaseException as e:
+            raise ProcessorError('Could not retrieve XML feed %s' % fusion_url)
 
-		build_re = re.compile('^fusion\/([\d\.]+)\/(\d+)\/')
+        build_re = re.compile('^fusion\/([\d\.]+)\/(\d+)\/')
 
-		last_build_no = 0
-		last_url_part = None
+        last_build_no = 0
+        last_url_part = None
 
-		fusion_feed = parseString(fusion_xml)
+        fusion_feed = parseString(fusion_xml)
 
-		# loop through the various products and versions in the XML file
-		# to find the one we want with the correct version
-		for i in  fusion_feed.getElementsByTagName('metadata'):
-			productId = i.getElementsByTagName('productId')[0].firstChild.nodeValue
-			version = i.getElementsByTagName('version')[0].firstChild.nodeValue
-			url = i.getElementsByTagName('url')[0].firstChild.nodeValue
+        # loop through the various products and versions in the XML file
+        # to find the one we want with the correct version
+        for i in  fusion_feed.getElementsByTagName('metadata'):
+            productId = i.getElementsByTagName('productId')[0].firstChild.nodeValue
+            version = i.getElementsByTagName('version')[0].firstChild.nodeValue
+            url = i.getElementsByTagName('url')[0].firstChild.nodeValue
 
-			if productId == 'fusion' and version == version_series:
+            if productId == 'fusion' and version == version_series:
 
-				match = build_re.search(url)
+                match = build_re.search(url)
 
-				if match:
-					build_ver = match.group(1)
-					build_no = match.group(2)
-					url_part = match.group(0)
+                if match:
+                    build_ver = match.group(1)
+                    build_no = match.group(2)
+                    url_part = match.group(0)
 
-					if build_no > last_build_no:
-						last_build_no = build_no
-						last_url_part = url_part
+                    if build_no > last_build_no:
+                        last_build_no = build_no
+                        last_url_part = url_part
 
-		if last_url_part:
-			self.output('Version: %s, Build: %s' % (build_ver, build_no))
-			return FUSION_URL_BASE + last_url_part + DARWIN_TOOLS_URL_APPEND
-		else:
-			raise ProcessorError('Could not find suitable version/build')
+        if last_url_part:
+            self.output('Version: %s, Build: %s' % (build_ver, build_no))
+            return FUSION_URL_BASE + last_url_part + DARWIN_TOOLS_URL_APPEND
+        else:
+            raise ProcessorError('Could not find suitable version/build')
 
-	def main(self):
-		version_series = self.env.get('VERSION_SERIES', DEFAULT_VERSION_SERIES)
+    def main(self):
+        version_series = self.env.get('VERSION_SERIES', DEFAULT_VERSION_SERIES)
 
-		self.env['url'] = self.get_url(version_series)
-		self.output('File URL %s' % self.env['url'])
+        self.env['url'] = self.get_url(version_series)
+        self.output('File URL %s' % self.env['url'])

--- a/VMware/VMwareToolsURLProvider.py
+++ b/VMware/VMwareToolsURLProvider.py
@@ -5,12 +5,7 @@ from __future__ import absolute_import
 import re
 from xml.dom.minidom import parseString
 
-from autopkglib import Processor, ProcessorError
-
-try:
-    from urllib.request import urlopen  # For Python 3
-except ImportError:
-    from urllib2 import urlopen  # For Python 2
+from autopkglib import Processor, ProcessorError, URLGetter
 
 __all__ = ["VMwareToolsURLProvider"]
 
@@ -18,7 +13,7 @@ FUSION_URL_BASE = 'https://softwareupdate.vmware.com/cds/vmw-desktop/'
 DARWIN_TOOLS_URL_APPEND = 'packages/com.vmware.fusion.tools.darwin.zip.tar'
 DEFAULT_VERSION_SERIES = '11.0.0'
 
-class VMwareToolsURLProvider(Processor):
+class VMwareToolsURLProvider(URLGetter):
     '''Provides URL to the latest Darwin ISO of the VMware Fusion tools.'''
 
     input_variables = {
@@ -36,9 +31,7 @@ class VMwareToolsURLProvider(Processor):
     def get_url(self, version_series):
         try:
             fusion_url = FUSION_URL_BASE + '/fusion.xml'
-            f = urlopen(fusion_url)
-            fusion_xml = f.read()
-            f.close()
+            fusion_xml = self.download(fusion_url)
         except Exception as e:
             raise ProcessorError('Could not retrieve XML feed %s' % fusion_url)
 
@@ -65,7 +58,7 @@ class VMwareToolsURLProvider(Processor):
                     build_no = match.group(2)
                     url_part = match.group(0)
 
-                    if build_no > last_build_no:
+                    if int(build_no) > int(last_build_no):
                         last_build_no = build_no
                         last_url_part = url_part
 


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including `urllib2.HTTPRedirectHandler`), but this should catch the low-hanging fruit right now.