### PR TITLE
Deprecate TrueCrypt recipe

### DIFF
--- a/TrueCrypt/TrueCrypt.munki.recipe
+++ b/TrueCrypt/TrueCrypt.munki.recipe
@@ -36,6 +36,10 @@
 	<array>
 		<dict>
 			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>TrueCryptURLProvider</string>
 		</dict>
 		<dict>


### PR DESCRIPTION
From http://truecrypt.sourceforge.net:

> WARNING: Using TrueCrypt is not secure as it may contain unfixed security issues