### PR TITLE
Adjust URLDownloader argument

### DIFF
--- a/Hightail/HightailDesktopApp.munki.recipe
+++ b/Hightail/HightailDesktopApp.munki.recipe
@@ -47,7 +47,7 @@
 			<dict>
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
-				<key>name</key>
+				<key>filename</key>
 				<string>%NAME%.dmg</string>
 			</dict>
 			<key>Processor</key>


### PR DESCRIPTION
The correct argument name for [URLDownloader](https://github.com/autopkg/autopkg/wiki/Processor-URLDownloader) is `filename`.