### PR TITLE
Update VirtualBoxURLProvider.py to workaround extraneous entries in MD5SUMS.

### DIFF
--- a/Oracle/VirtualBoxURLProvider.py
+++ b/Oracle/VirtualBoxURLProvider.py
@@ -17,8 +17,8 @@ UPDATE_CHECK_URL = 'https://update.virtualbox.org/query.php?platform=DARWIN_64BI
 ROOT_URL = 'https://download.virtualbox.org/virtualbox'
 LATEST_URL = ROOT_URL + '/LATEST.TXT'
 
-re_vbox = re.compile(r'(VirtualBox-([0-9\.]*)-[0-9]*-OSX\.dmg$)')
-re_ext = re.compile(r'(Oracle_VM_VirtualBox_Extension_Pack-[0-9\.]*-[0-9]*\.vbox-extpack$)')
+re_vbox = re.compile(r'(VirtualBox-([0-9\.]*)-[0-9]*-OSX\.dmg)$', re.MULTILINE)
+re_ext = re.compile(r'(Oracle_VM_VirtualBox_Extension_Pack-[0-9\.]*-[0-9]*\.vbox-extpack)$', re.MULTILINE)
 
 class VirtualBoxURLProvider(URLGetter):
     '''Provides URL to the latest VirtualBox version.'''

--- a/Oracle/VirtualBoxURLProvider.py
+++ b/Oracle/VirtualBoxURLProvider.py
@@ -17,8 +17,8 @@ UPDATE_CHECK_URL = 'https://update.virtualbox.org/query.php?platform=DARWIN_64BI
 ROOT_URL = 'https://download.virtualbox.org/virtualbox'
 LATEST_URL = ROOT_URL + '/LATEST.TXT'
 
-re_vbox = re.compile(r'(VirtualBox-([0-9\.]*)-[0-9]*-OSX\.dmg)')
-re_ext = re.compile(r'(Oracle_VM_VirtualBox_Extension_Pack-[0-9\.]*-[0-9]*\.vbox-extpack)')
+re_vbox = re.compile(r'(VirtualBox-([0-9\.]*)-[0-9]*-OSX\.dmg$)')
+re_ext = re.compile(r'(Oracle_VM_VirtualBox_Extension_Pack-[0-9\.]*-[0-9]*\.vbox-extpack$)')
 
 class VirtualBoxURLProvider(URLGetter):
     '''Provides URL to the latest VirtualBox version.'''


### PR DESCRIPTION
The [MD5SUMS](https://download.virtualbox.org/virtualbox/6.1.20/MD5SUMS) file contains extraneous entries ending in `.delete`:
```
d41d8cd98f00b204e9800998ecf8427e *Oracle_VM_VirtualBox_Extension_Pack-6.1.20-143848.vbox-extpack.delete
d41d8cd98f00b204e9800998ecf8427e *Oracle_VM_VirtualBox_Extension_Pack-6.1.20-143869.vbox-extpack.delete
66e34c2689f23102fb633778504057b4 *Oracle_VM_VirtualBox_Extension_Pack-6.1.20-143896.vbox-extpack
...
```
**Current invalid behaviour**
Oracle_VM_VirtualBox_Extension_Pack-6.1.20-143848.vbox-extpack (this file [does not exist](https://download.virtualbox.org/virtualbox/6.1.20/Oracle_VM_VirtualBox_Extension_Pack-6.1.20-143848.vbox-extpack) and it ends with .delete).

**Expected behaviour**
Oracle_VM_VirtualBox_Extension_Pack-6.1.20-143896.vbox-extpack (this file [exists](https://download.virtualbox.org/virtualbox/6.1.20/Oracle_VM_VirtualBox_Extension_Pack-6.1.20-143896.vbox-extpack)).

**Resolution**
To successfully parse the above MD5SUMS file, the regex expression needs to be anchored so that entries ending in .delete are ignored.
