### PR TITLE
Fix Papers recipes, add code signature verification, and add ARCH input variable

### DIFF
--- a/Mekentosj/Papers2.download.recipe
+++ b/Mekentosj/Papers2.download.recipe
@@ -19,7 +19,7 @@ Valid values for ARCH include:
 		<string>x64</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
@@ -45,6 +45,17 @@ Valid values for ARCH include:
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/Papers.app</string>
+				<key>requirement</key>
+				<string>identifier "com.ReadCube.Papers" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = FY6R4ETYH7</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
 		</dict>
 	</array>
 </dict>

--- a/Mekentosj/Papers2.download.recipe
+++ b/Mekentosj/Papers2.download.recipe
@@ -3,15 +3,20 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Find latest Papers2 from appcast and download.</string>
+	<string>Find latest Papers2 from appcast and download.
+
+Valid values for ARCH include:
+- "x64" (default, Intel)
+- "arm64" (Apple Silicon)
+</string>
 	<key>Identifier</key>
 	<string>com.github.jessepeterson.Papers2.download</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
-		<string>Papers2</string>
-		<key>SPARKLE_FEED_URL</key>
-		<string>https://www.papersapp.com/papers/appcast.xml</string>
+		<string>Papers</string>
+		<key>ARCH</key>
+		<string>x64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
@@ -20,17 +25,19 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>%SPARKLE_FEED_URL%</string>
+				<key>re_pattern</key>
+				<string>(Papers_Setup_[\d\.]+-%ARCH%\.dmg)</string>
+				<key>url</key>
+				<string>https://update.readcube.com/desktop/updates/latest-mac.yml</string>
 			</dict>
 			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>filename</key>
-				<string>%NAME%.dmg</string>
+				<key>url</key>
+				<string>https://update.readcube.com/desktop/updates/%match%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
This PR adjusts the download method for the latest version of the Papers app. It also adds code signature verification for the app, and adds an ARCH input variable that can be used to specify the desired architecture.

Verbose recipe run with default (Intel) architecture:

```
% autopkg run -vvq 'Mekentosj/Papers2.download.recipe'
Processing Mekentosj/Papers2.download.recipe...
WARNING: Mekentosj/Papers2.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(Papers_Setup_[\\d\\.]+-x64.dmg)',
           'url': 'https://update.readcube.com/desktop/updates/latest-mac.yml'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): Papers_Setup_4.37.2395-x64.dmg
{'Output': {'match': 'Papers_Setup_4.37.2395-x64.dmg'}}
URLDownloader
{'Input': {'url': 'https://update.readcube.com/desktop/updates/Papers_Setup_4.37.2395-x64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 26 Sep 2024 12:02:33 GMT
URLDownloader: Storing new ETag header: "5f2060910c646902e1fdd3cb222267a8-39"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jessepeterson.Papers2.download/downloads/Papers_Setup_4.37.2395-x64.dmg
{'Output': {'download_changed': True,
            'etag': '"5f2060910c646902e1fdd3cb222267a8-39"',
            'last_modified': 'Thu, 26 Sep 2024 12:02:33 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jessepeterson.Papers2.download/downloads/Papers_Setup_4.37.2395-x64.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jessepeterson.Papers2.download/downloads/Papers_Setup_4.37.2395-x64.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jessepeterson.Papers2.download/downloads/Papers_Setup_4.37.2395-x64.dmg/Papers.app',
           'requirement': 'identifier "com.ReadCube.Papers" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'FY6R4ETYH7'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jessepeterson.Papers2.download/downloads/Papers_Setup_4.37.2395-x64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.zP5H3t/Papers.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.zP5H3t/Papers.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.zP5H3t/Papers.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jessepeterson.Papers2.download/receipts/Papers2.download-receipt-20241226-192431.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jessepeterson.Papers2.download/downloads/Papers_Setup_4.37.2395-x64.dmg
```

Verbose recipe run with Apple Silicon architecture:

```
% autopkg run -vvq 'Mekentosj/Papers2.download.recipe' -k ARCH=arm64
Processing Mekentosj/Papers2.download.recipe...
WARNING: Mekentosj/Papers2.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(Papers_Setup_[\\d\\.]+-arm64\\.dmg)',
           'url': 'https://update.readcube.com/desktop/updates/latest-mac.yml'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): Papers_Setup_4.37.2395-arm64.dmg
{'Output': {'match': 'Papers_Setup_4.37.2395-arm64.dmg'}}
URLDownloader
{'Input': {'url': 'https://update.readcube.com/desktop/updates/Papers_Setup_4.37.2395-arm64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 26 Sep 2024 12:07:00 GMT
URLDownloader: Storing new ETag header: "a0d5e7ac9c018094f8387c39a27bdf53-38"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jessepeterson.Papers2.download/downloads/Papers_Setup_4.37.2395-arm64.dmg
{'Output': {'download_changed': True,
            'etag': '"a0d5e7ac9c018094f8387c39a27bdf53-38"',
            'last_modified': 'Thu, 26 Sep 2024 12:07:00 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jessepeterson.Papers2.download/downloads/Papers_Setup_4.37.2395-arm64.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jessepeterson.Papers2.download/downloads/Papers_Setup_4.37.2395-arm64.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jessepeterson.Papers2.download/downloads/Papers_Setup_4.37.2395-arm64.dmg/Papers.app',
           'requirement': 'identifier "com.ReadCube.Papers" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'FY6R4ETYH7'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jessepeterson.Papers2.download/downloads/Papers_Setup_4.37.2395-arm64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.tqrjW2/Papers.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.tqrjW2/Papers.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.tqrjW2/Papers.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jessepeterson.Papers2.download/receipts/Papers2.download-receipt-20241226-192501.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jessepeterson.Papers2.download/downloads/Papers_Setup_4.37.2395-arm64.dmg
```
