### PR TITLE
Fix Neat Desktop recipes

### DIFF
--- a/Neat/Neat.download.recipe
+++ b/Neat/Neat.download.recipe
@@ -3,15 +3,20 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Find latest Neat from appcast and download.</string>
+	<string>Find latest Neat from appcast and download.
+	
+Valid values for ARCH include:
+- "Intel" (default)
+- "ARM" (Apple Silicon)
+</string>
 	<key>Identifier</key>
 	<string>com.github.jessepeterson.Neat.download</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>Neat</string>
-		<key>SPARKLE_FEED_URL</key>
-		<string>http://cdn.neatco.com/appcast.xml</string>
+		<key>ARCH</key>
+		<string>Intel</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
@@ -20,12 +25,17 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>%SPARKLE_FEED_URL%</string>
+				<key>re_pattern</key>
+				<string>href="(https://neat-marketing\.s3\.amazonaws\.com/support/Articles/Neat%20Desktop%20Application/NeatDesktop-[\d\.]+-%ARCH%\.dmg)"</string>
+				<key>result_output_var_name</key>
+				<string>url</string>
+				<key>url</key>
+				<string>https://support.neat.com/desktop/new-neat-desktop-application#downloads</string>
 			</dict>
 			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
+			<string>URLTextSearcher</string>
 		</dict>
+
 		<dict>
 			<key>Arguments</key>
 			<dict>
@@ -38,6 +48,17 @@
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/Neat® Desktop.app</string>
+				<key>requirement</key>
+				<string>identifier "com.neat.desktop" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = WZWUP793NV</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
 		</dict>
 	</array>
 </dict>

--- a/Neat/Neat.munki.recipe
+++ b/Neat/Neat.munki.recipe
@@ -28,10 +28,6 @@
 			<string>The Neat Company</string>
 			<key>display_name</key>
 			<string>Neat</string>
-			<key>blocking_applications</key>
-			<array>
-				<string>Neat</string>
-			</array>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>
@@ -44,94 +40,6 @@
 	<string>com.github.jessepeterson.Neat.download</string>
 	<key>Process</key>
 	<array>
-		<dict>
-			<key>Processor</key>
-			<string>FlatPkgUnpacker</string>
-			<key>Arguments</key>
-			<dict>
-				<key>flat_pkg_path</key>
-				<string>%pathname%/*.pkg</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>PkgRootCreator</string>
-			<key>Arguments</key>
-			<dict>
-				<key>pkgroot</key>
-				<string>%RECIPE_CACHE_DIR%/pkgroot</string>
-				<key>pkgdirs</key>
-				<dict>
-					<key>Applications</key>
-					<string>0755</string>
-				</dict>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>PkgPayloadUnpacker</string>
-			<key>Arguments</key>
-			<dict>
-				<key>purge_destination</key>
-				<true/>
-				<key>pkg_payload_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/Neat.pkg/Payload</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/pkgroot</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>Versioner</string>
-			<key>Arguments</key>
-			<dict>
-				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/pkgroot/Applications/Neat.app/Contents/Info.plist</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>MunkiPkginfoMerger</string>
-			<key>Arguments</key>
-			<dict>
-				<key>additional_pkginfo</key>
-				<dict>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>MunkiInstallsItemsCreator</string>
-			<key>Arguments</key>
-			<dict>
-				<key>faux_root</key>
-				<string>%RECIPE_CACHE_DIR%/pkgroot</string>
-				<key>installs_item_paths</key>
-				<array>
-					<string>/Applications/Neat.app</string>
-				</array>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>MunkiPkginfoMerger</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>PathDeleter</string>
-			<key>Arguments</key>
-			<dict>
-				<key>path_list</key>
-				<array>
-					<string>%RECIPE_CACHE_DIR%/unpack</string>
-					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
-				</array>
-			</dict>
-		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
This PR updates the download method for Neat Desktop, as well as adjusting for the dmg download format.

Verbose download recipe run output:

```
% autopkg run -vvq 'Neat/Neat.download.recipe'
Processing Neat/Neat.download.recipe...
WARNING: Neat/Neat.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://neat-marketing\\.s3\\.amazonaws\\.com/support/Articles/Neat%20Desktop%20Application/NeatDesktop-[\\d\\.]+-Intel\\.dmg)"',
           'result_output_var_name': 'url',
           'url': 'https://support.neat.com/desktop/new-neat-desktop-application#downloads'}}
URLTextSearcher: Found matching text (url): https://neat-marketing.s3.amazonaws.com/support/Articles/Neat%20Desktop%20Application/NeatDesktop-2.0.0-Intel.dmg
{'Output': {'url': 'https://neat-marketing.s3.amazonaws.com/support/Articles/Neat%20Desktop%20Application/NeatDesktop-2.0.0-Intel.dmg'}}
URLDownloader
{'Input': {'filename': 'Neat.dmg',
           'url': 'https://neat-marketing.s3.amazonaws.com/support/Articles/Neat%20Desktop%20Application/NeatDesktop-2.0.0-Intel.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 10 Dec 2024 19:58:22 GMT
URLDownloader: Storing new ETag header: "1e677570291f5cc985fdf37a2002bf57"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jessepeterson.Neat.download/downloads/Neat.dmg
{'Output': {'download_changed': True,
            'etag': '"1e677570291f5cc985fdf37a2002bf57"',
            'last_modified': 'Tue, 10 Dec 2024 19:58:22 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jessepeterson.Neat.download/downloads/Neat.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jessepeterson.Neat.download/downloads/Neat.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jessepeterson.Neat.download/downloads/Neat.dmg/Neat® '
                         'Desktop.app',
           'requirement': 'identifier "com.neat.desktop" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'WZWUP793NV'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jessepeterson.Neat.download/downloads/Neat.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.xSpukw/Neat® Desktop.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.xSpukw/Neat® Desktop.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.xSpukw/Neat® Desktop.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jessepeterson.Neat.download/receipts/Neat.download-receipt-20241226-191126.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jessepeterson.Neat.download/downloads/Neat.dm
```

Verbose munki recipe run output:

```
% autopkg run -vvq 'Neat/Neat.munki.recipe'
Processing Neat/Neat.munki.recipe...
WARNING: Neat/Neat.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://neat-marketing\\.s3\\.amazonaws\\.com/support/Articles/Neat%20Desktop%20Application/NeatDesktop-[\\d\\.]+-Intel\\.dmg)"',
           'result_output_var_name': 'url',
           'url': 'https://support.neat.com/desktop/new-neat-desktop-application#downloads'}}
URLTextSearcher: Found matching text (url): https://neat-marketing.s3.amazonaws.com/support/Articles/Neat%20Desktop%20Application/NeatDesktop-2.0.0-Intel.dmg
{'Output': {'url': 'https://neat-marketing.s3.amazonaws.com/support/Articles/Neat%20Desktop%20Application/NeatDesktop-2.0.0-Intel.dmg'}}
URLDownloader
{'Input': {'filename': 'Neat.dmg',
           'url': 'https://neat-marketing.s3.amazonaws.com/support/Articles/Neat%20Desktop%20Application/NeatDesktop-2.0.0-Intel.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 10 Dec 2024 19:58:22 GMT
URLDownloader: Storing new ETag header: "1e677570291f5cc985fdf37a2002bf57"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jessepeterson.Neat.munki/downloads/Neat.dmg
{'Output': {'download_changed': True,
            'etag': '"1e677570291f5cc985fdf37a2002bf57"',
            'last_modified': 'Tue, 10 Dec 2024 19:58:22 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jessepeterson.Neat.munki/downloads/Neat.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jessepeterson.Neat.munki/downloads/Neat.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jessepeterson.Neat.munki/downloads/Neat.dmg/Neat® '
                         'Desktop.app',
           'requirement': 'identifier "com.neat.desktop" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'WZWUP793NV'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jessepeterson.Neat.munki/downloads/Neat.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.d2gPZr/Neat® Desktop.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.d2gPZr/Neat® Desktop.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.d2gPZr/Neat® Desktop.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.jessepeterson.Neat.munki/downloads/Neat.dmg',
           'pkginfo': {'blocking_applications': ['Neat'],
                       'catalogs': ['testing'],
                       'category': 'Utilities',
                       'description': 'Simple and intuitive, Neat for Mac lets '
                                      'you scan and organize receipts, '
                                      'business cards, reports, recipes, and '
                                      'other important documents with ease.',
                       'developer': 'The Neat Company',
                       'display_name': 'Neat',
                       'name': 'Neat',
                       'unattended_install': True},
           'repo_subdirectory': 'apps'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Neat-2.0.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Neat-2.0.0.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'Neat',
                                                       'pkg_repo_path': 'apps/Neat-2.0.0.dmg',
                                                       'pkginfo_path': 'apps/Neat-2.0.0.plist',
                                                       'version': '2.0.0'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2024, 12, 27, 3, 13, 36),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'blocking_applications': ['Neat'],
                           'catalogs': ['testing'],
                           'category': 'Utilities',
                           'description': 'Simple and intuitive, Neat for Mac '
                                          'lets you scan and organize '
                                          'receipts, business cards, reports, '
                                          'recipes, and other important '
                                          'documents with ease.',
                           'developer': 'The Neat Company',
                           'display_name': 'Neat',
                           'installer_item_hash': '9ed579a22104df5a256ab3802c3d72032886ce744e7e77667710331fe37e6b27',
                           'installer_item_location': 'apps/Neat-2.0.0.dmg',
                           'installer_item_size': 103309,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.neat.desktop',
                                         'CFBundleName': 'Neat® Desktop',
                                         'CFBundleShortVersionString': '2.0.0',
                                         'CFBundleVersion': '2.0.0.2024120507 '
                                                            'x64',
                                         'minosversion': '10.11.0',
                                         'path': '/Applications/Neat® '
                                                 'Desktop.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'Neat® '
                                                             'Desktop.app'}],
                           'minimum_os_version': '10.11.0',
                           'name': 'Neat',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '2.0.0'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/Neat-2.0.0.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/Neat-2.0.0.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jessepeterson.Neat.munki/receipts/Neat.munki-receipt-20241226-191336.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jessepeterson.Neat.munki/downloads/Neat.dmg

The following new items were imported into Munki:
    Name  Version  Catalogs  Pkginfo Path           Pkg Repo Path        Icon Repo Path
    ----  -------  --------  ------------           -------------        --------------
    Neat  2.0.0    testing   apps/Neat-2.0.0.plist  apps/Neat-2.0.0.dmg
```

