### PR TITLE
Update Basecamp3.download.recipe

### DIFF
--- a/Basecamp/Basecamp3.download.recipe
+++ b/Basecamp/Basecamp3.download.recipe
@@ -32,7 +32,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/Basecamp 3.app</string>
+				<string>%pathname%/Basecamp.app</string>
 				<key>requirement</key>
 				<string>identifier "com.basecamp.basecamp3" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2WNYUYRS7G"</string>
 			</dict>


### PR DESCRIPTION
apparently basecamp updated the app to `Basecamp.app` from `Basecamp 3.app` within the dmg.