### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/4D/4D.download.recipe
+++ b/4D/4D.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>4D</string>
 		<key>PRODUCT_URL</key>
-		<string>http://www.4d.com/downloads/products.html</string>
+		<string>https://www.4d.com/downloads/products.html</string>
 		<key>DOWNLOAD_RE</key>
 		<string>(?P&lt;url&gt;http://download.4d.com/Products/Current/4D_v[0-9]+_[0-9]+/4D_v(?P&lt;version&gt;[0-9]+\.[0-9\.]+)_Mac.dmg)</string>
 	</dict>

--- a/Extensis/PortfolioClient10.munki.recipe
+++ b/Extensis/PortfolioClient10.munki.recipe
@@ -65,7 +65,7 @@ exit
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>http://www.extensis.com/support/product-support/portfolio-server-10/</string>
+				<string>https://www.extensis.com/support/product-support/portfolio-server-10/</string>
 				<key>re_pattern</key>
 				<string>(?P&lt;url&gt;http://dl.extensis.com/downloads/../EN/M/Portfolio-Client-M-10-[0-9-]*\.zip)</string>
 			</dict>

--- a/Extensis/PortfolioClient11.munki.recipe
+++ b/Extensis/PortfolioClient11.munki.recipe
@@ -63,7 +63,7 @@ exit
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>http://www.extensis.com/support/product-support/portfolio-server-11/</string>
+				<string>https://www.extensis.com/support/product-support/portfolio-server-11/</string>
 				<key>re_pattern</key>
 				<string>(?P&lt;url&gt;http://bin.extensis.com/Portfolio-Server-Client-M-11-[0-9-]*\.zip)</string>
 			</dict>

--- a/Extensis/UniversalTypeClient3.munki.recipe
+++ b/Extensis/UniversalTypeClient3.munki.recipe
@@ -446,7 +446,7 @@ COMMENTBLOCK</string>
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>http://www.extensis.com/support/product-support/universal-type-server-3/</string>
+				<string>https://www.extensis.com/support/product-support/universal-type-server-3/</string>
 				<key>re_pattern</key>
 				<string>(?P&lt;url&gt;http://bin.extensis.com/UTC-3-[0-9\-]*-M\.zip)</string>
 			</dict>

--- a/MOOSProjectViewer/MOOSProjectViewer.download.recipe
+++ b/MOOSProjectViewer/MOOSProjectViewer.download.recipe
@@ -28,7 +28,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>http://www.moosprojectviewer.com/%url_part%</string>
+				<string>https://www.moosprojectviewer.com/%url_part%</string>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 			</dict>

--- a/NIH-RSB/ImageJ.munki.recipe
+++ b/NIH-RSB/ImageJ.munki.recipe
@@ -85,7 +85,7 @@ rm -rf /Applications/ImageJ
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>http://wsr.imagej.net/distros/osx/</string>
+				<string>https://wsr.imagej.net/distros/osx/</string>
 				<key>re_pattern</key>
 				<string>ImageJ[0-9]*\.zip</string>
 			</dict>
@@ -96,7 +96,7 @@ rm -rf /Applications/ImageJ
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>http://wsr.imagej.net/distros/osx/%match%</string>
+				<string>https://wsr.imagej.net/distros/osx/%match%</string>
 				<key>filename</key>
 				<string>%NAME%.zip</string>
 			</dict>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._