### PR TITLE
Update to deal with Basecamp version 5

### DIFF
--- a/Basecamp/Basecamp3.download.recipe
+++ b/Basecamp/Basecamp3.download.recipe
@@ -3,13 +3,15 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads latest Basecamp 3 Mac app.</string>
+	<string>Downloads latest Basecamp 3 Mac app. Leave PLATFORM blank for Intel, set PLATFORM to "_arm64" for Arm.</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.jessepeterson-recipes.download.Basecamp3</string>
 	<key>Input</key>
 	<dict>
+		<key>PLATFORM</key>
+		<string></string>
 		<key>DOWNLOAD_URL</key>
-		<string>https://bc3-desktop.s3.amazonaws.com/mac/basecamp3.dmg</string>
+		<string>https://bc3-desktop.s3.amazonaws.com/mac%PLATFORM%/basecamp3%PLATFORM%.dmg</string>
 		<key>NAME</key>
 		<string>Basecamp3</string>
 	</dict>

--- a/Basecamp/Basecamp3.download.recipe
+++ b/Basecamp/Basecamp3.download.recipe
@@ -77,22 +77,20 @@ certificate leaf[subject.OU] = "2WNYUYRS7G"
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>
-			<dict>
-				<key>Processor</key>
-				<string>Copier</string>
-
-				<key>Arguments</key>
-					<dict>
-						<key>source_path</key>
-						<string>%pathname%</string>
-
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.dmg</string>
-			</dict>
 		</dict>
-	</dict>
+		<dict>
+			<key>Processor</key>
+			<string>Copier</string>
 
+			<key>Arguments</key>
+				<dict>
+					<key>source_path</key>
+					<string>%pathname%</string>
+
+					<key>destination_path</key>
+					<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.dmg</string>
+				</dict>
+		</dict>
 	</array>
-
 </dict>
 </plist>

--- a/Basecamp/Basecamp3.download.recipe
+++ b/Basecamp/Basecamp3.download.recipe
@@ -77,7 +77,20 @@ certificate leaf[subject.OU] = "2WNYUYRS7G"
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>
+			<dict>
+				<key>Processor</key>
+				<string>Copier</string>
+
+				<key>Arguments</key>
+					<dict>
+						<key>source_path</key>
+						<string>%pathname%</string>
+
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.dmg</string>
+			</dict>
 		</dict>
+	</dict>
 
 	</array>
 

--- a/Basecamp/Basecamp3.download.recipe
+++ b/Basecamp/Basecamp3.download.recipe
@@ -3,48 +3,98 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads latest Basecamp 3 Mac app. Leave PLATFORM blank for Intel, set PLATFORM to "_arm64" for Arm.</string>
+	<string>
+	Downloads the latest Basecamp 5 Mac app.
+	Set PLATFORM to arm64 for Apple Silicon or x64 for Intel.
+	</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.jessepeterson-recipes.download.Basecamp3</string>
 	<key>Input</key>
 	<dict>
 		<key>PLATFORM</key>
-		<string></string>
+		<string>arm64</string>
 		<key>DOWNLOAD_URL</key>
-		<string>https://bc3-desktop.s3.amazonaws.com/mac%PLATFORM%/basecamp3%PLATFORM%.dmg</string>
+		<string>https://basecamp.com/desktop/Basecamp-mac-%PLATFORM%.dmg</string>
 		<key>NAME</key>
-		<string>Basecamp3</string>
+		<string>Basecamp</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2</string>
+	<string>1.0.0</string>
 	<key>Process</key>
 	<array>
+
+		<!-- Download DMG -->
 		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
+
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
 		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_path</key>
-				<string>%pathname%/Basecamp 3.app</string>
-				<key>requirement</key>
-				<string>identifier "com.basecamp.basecamp3" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2WNYUYRS7G"</string>
-			</dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-		</dict>
+
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
+
+		<!-- Verify app signature -->
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/Basecamp.app</string>
+
+				<key>requirement</key>
+				<string>
+identifier "com.basecamp.basecamp3" and
+anchor apple generic and
+certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and
+certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and
+certificate leaf[subject.OU] = "2WNYUYRS7G"
+				</string>
+			</dict>
+		</dict>
+
+		<!-- Extract version -->
+		<dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%pathname%/Basecamp.app/Contents/Info.plist</string>
+
+				<key>plist_version_key</key>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+		</dict>
+
+		<!-- Rename downloaded DMG -->
+		<dict>
+			<key>Processor</key>
+			<string>FileMover</string>
+
+			<key>Arguments</key>
+			<dict>
+				<key>source</key>
+				<string>%pathname%</string>
+
+				<key>target</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.dmg</string>
+			</dict>
+		</dict>
+
 	</array>
+
 </dict>
 </plist>

--- a/Basecamp/Basecamp3.download.recipe
+++ b/Basecamp/Basecamp3.download.recipe
@@ -79,21 +79,6 @@ certificate leaf[subject.OU] = "2WNYUYRS7G"
 			</dict>
 		</dict>
 
-		<!-- Rename downloaded DMG -->
-		<dict>
-			<key>Processor</key>
-			<string>FileMover</string>
-
-			<key>Arguments</key>
-			<dict>
-				<key>source</key>
-				<string>%pathname%</string>
-
-				<key>target</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.dmg</string>
-			</dict>
-		</dict>
-
 	</array>
 
 </dict>

--- a/Basecamp/Basecamp3.munki.recipe
+++ b/Basecamp/Basecamp3.munki.recipe
@@ -3,11 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Imports Basecamp 3 app into Munki.</string>
+	<string>Imports Basecamp 3 app into Munki. Leave PLATFORM blank for Intel, set PLATFORM to "_arm64" for Arm. Set ARCHITECTURE to "x86_64" for Intel or "arm64" for Arm.</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.jessepeterson-recipes.munki.Basecamp3</string>
 	<key>Input</key>
 	<dict>
+		<key>PLATFORM</key>
+		<string></string>
 		<key>MUNKI_CATEGORY</key>
 		<string>Collaboration</string>
 		<key>MUNKI_REPO_SUBDIR</key>
@@ -23,13 +25,17 @@
 			<key>category</key>
 			<string>%MUNKI_CATEGORY%</string>
 			<key>description</key>
-			<string>We built Basecamp 3 to work beautifully on your Mac, Macbook and iMac. Keep Basecamp 3 handy in the dock and get notifications right on your desktop. </string>
+			<string>We built Basecamp 3 %PLATFORM% to work beautifully on your Mac, Macbook and iMac. Keep Basecamp 3 handy in the dock and get notifications right on your desktop. </string>
 			<key>developer</key>
 			<string>Basecamp</string>
 			<key>display_name</key>
 			<string>Basecamp 3 for Mac</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>supported_architectures</key>
+			<array>
+			<string>%ARCHITECTURE%</string>
+			</array>
 			<key>unattended_install</key>
 			<true/>
 		</dict>

--- a/Basecamp/Basecamp3.munki.recipe
+++ b/Basecamp/Basecamp3.munki.recipe
@@ -11,7 +11,7 @@
 		<key>PLATFORM</key>
 		<string></string>
 		<key>ARCHITECTURE</key>
-		<string></string>
+		<string>x86_64</string>
 		<key>MUNKI_CATEGORY</key>
 		<string>Collaboration</string>
 		<key>MUNKI_REPO_SUBDIR</key>

--- a/Basecamp/Basecamp3.munki.recipe
+++ b/Basecamp/Basecamp3.munki.recipe
@@ -15,7 +15,7 @@
 		<key>MUNKI_CATEGORY</key>
 		<string>Collaboration</string>
 		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps</string>
+		<string>apps/Basecamp/%PLATFORM%</string>
 		<key>NAME</key>
 		<string>Basecamp3</string>
 		<key>pkginfo</key>

--- a/Basecamp/Basecamp3.munki.recipe
+++ b/Basecamp/Basecamp3.munki.recipe
@@ -10,6 +10,8 @@
 	<dict>
 		<key>PLATFORM</key>
 		<string></string>
+		<key>ARCHITECTURE</key>
+		<string></string>
 		<key>MUNKI_CATEGORY</key>
 		<string>Collaboration</string>
 		<key>MUNKI_REPO_SUBDIR</key>

--- a/Basecamp/Basecamp3.munki.recipe
+++ b/Basecamp/Basecamp3.munki.recipe
@@ -3,21 +3,26 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Imports Basecamp 3 app into Munki. Leave PLATFORM blank for Intel, set PLATFORM to "_arm64" for Arm. Set ARCHITECTURE to "x86_64" for Intel or "arm64" for Arm.</string>
+		<string>
+	Imports the latest Basecamp 5 Mac app.
+	Set PLATFORM to arm64 for Apple Silicon or x64 for Intel.
+	Set ARCHITECTURE to arm64 for Apple Silicon or x86_64 for Intel
+	</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.jessepeterson-recipes.munki.Basecamp3</string>
 	<key>Input</key>
 	<dict>
-		<key>PLATFORM</key>
-		<string></string>
-		<key>ARCHITECTURE</key>
-		<string>x86_64</string>
 		<key>MUNKI_CATEGORY</key>
 		<string>Collaboration</string>
 		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps/Basecamp/%PLATFORM%</string>
+		<string>apps</string>
 		<key>NAME</key>
-		<string>Basecamp3</string>
+		<string>Basecamp</string>
+		<!-- Default architecture -->
+		<key>PLATFORM</key>
+		<string>arm64</string>
+		<key>ARCHITECTURE</key>
+		<string>arm64</string>	
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>
@@ -27,17 +32,16 @@
 			<key>category</key>
 			<string>%MUNKI_CATEGORY%</string>
 			<key>description</key>
-			<string>We built Basecamp 3 %PLATFORM% to work beautifully on your Mac, Macbook and iMac. Keep Basecamp 3 handy in the dock and get notifications right on your desktop. </string>
+			<string>We built Basecamp 5 to work beautifully on your Mac, Macbook and iMac. Keep Basecamp 5 handy in the dock and get notifications right on your desktop. </string>
 			<key>developer</key>
 			<string>Basecamp</string>
 			<key>display_name</key>
-			<string>Basecamp 3 for Mac</string>
+			<string>Basecamp 5 %PLATFORM%</string>
 			<key>name</key>
-			<string>%NAME%</string>
 			<key>supported_architectures</key>
 			<array>
-			<string>%ARCHITECTURE%</string>
-			</array>
+				<string>%ARCHITECTURE%</string>
+			<string>%NAME%</string>
 			<key>unattended_install</key>
 			<true/>
 		</dict>

--- a/Basecamp/Basecamp3.munki.recipe
+++ b/Basecamp/Basecamp3.munki.recipe
@@ -38,10 +38,11 @@
 			<key>display_name</key>
 			<string>Basecamp 5 %PLATFORM%</string>
 			<key>name</key>
+			<string>%NAME%</string>
 			<key>supported_architectures</key>
 			<array>
 				<string>%ARCHITECTURE%</string>
-			<string>%NAME%</string>
+			</array>
 			<key>unattended_install</key>
 			<true/>
 		</dict>


### PR DESCRIPTION
Although the Identifier still refers to basecamp3, the app itself is now called simply "Basecamp" and the version is now 5.x.x. These changes download and install the newest version of arm64 and intel based on the ARCHITECTURE and PLATFORM variables. (arm64 is now the default).